### PR TITLE
fix: Wrong Windows MIME types in regedit will cause browser to refuse execute the renderer bundle

### DIFF
--- a/render/server.py
+++ b/render/server.py
@@ -12,6 +12,16 @@ import sys
 import urllib.parse
 from pathlib import Path
 
+"""Windows resolves MIME types from HKEY_CLASSES_ROOT, and a polluted
+``.js`` -> ``text/plain`` entry there silently overrides the stdlib table.
+The browser then refuses to execute the renderer bundle and the wallpaper 
+page stays black.  Declare the executable types this server owns so the 
+response never depends on client machine state.
+"""
+mimetypes.add_type("text/javascript", ".js")
+mimetypes.add_type("text/javascript", ".mjs")
+mimetypes.add_type("application/wasm", ".wasm")
+
 
 class _CORSHandler(http.server.SimpleHTTPRequestHandler):
     """Local asset handler with browser-readable secrets kept out of scope.


### PR DESCRIPTION
## What and why

在`render/server.py` 中，Windows会从注册表中读取`mimetypes`。假如注册表中的`.js`值被某些软件错误改为了`text/plain`，那么bundle中的所有`.js`都会被解析为`text/plain`，而`nosniff`设置会导致浏览器拒绝执行，最终wallpaper会变成黑屏。

解决方式是在代码中规定`.js`被解析为`text/javascript`，避免被用户电脑本身的设置影响。

In `render/server.py`, Windows reads `mimetypes` from the registry. If the `.js` value in the registry has been incorrectly changed to `text/plain` by some software, all `.js` files in the bundle will be served as `text/plain`. With `nosniff` enabled, the browser will refuse to execute these files, ultimately causing the wallpaper to display a black screen.

The solution is to explicitly specify `text/javascript` as the MIME type for `.js` files in the code, preventing the behavior from being affected by the user's local system configuration.


## Change class

- [x] Routine fix, documentation, test, maintenance, or presentation-only UI
- [ ] Product-semantic or public-contract change discussed in the linked Issue
- [ ] Isolated, default-off experiment

Owning layer:

User-visible effect, or `none`:

Compatibility or migration impact, or `none`:

## Evidence

Commands and manual journeys run:

- [x] Relevant Python tests pass
- [x] CPU/model-less baseline remains supported
- [ ] Electron `npm run build` passes when Electron code changed
- [ ] Dependency audit passes when dependencies changed
- [ ] Before/after screenshots are attached for visible UI changes
- [ ] Documentation/examples are updated for changed settings or contracts

## Final check

- [x] This PR addresses one coherent problem without unrelated cleanup
- [x] It does not add a speculative API, fallback, or compatibility path
- [x] No secrets, local state, model weights, voice material, or restricted assets are included
- [x] Third-party notices and provenance are preserved
