### PR TITLE
API key 读取容忍首尾引号与空白

### DIFF
--- a/config/environment.py
+++ b/config/environment.py
@@ -99,6 +99,19 @@ class EnvironmentReader:
         raw = self._raw(key, aliases)
         return str(default) if raw is None else str(raw)
 
+    def secret(self, key: str, default: str = "", *, aliases: tuple[str, ...] = ()) -> str:
+        """Read one API key/token, tolerating accidental .env edits.
+
+        Single normalization contract shared by settings, browser providers
+        and provider command auth so every consumer of the same key observes
+        the same value. Inherit the standard authority order: an already-set
+        process value wins over the project .env (which load_dotenv has
+        already merged into the process environment without override).
+        """
+        self._register(key, "secret", default, aliases)
+        raw = self._raw(key, aliases)
+        return str(default) if raw is None else secret_value(raw)
+
     def fields(self) -> tuple[ConfigField, ...]:
         return tuple(self._fields[key] for key in sorted(self._fields))
 
@@ -118,6 +131,34 @@ def load_project_environment(project_root: Path) -> EnvironmentReader:
 
 _PROJECT_ENVIRONMENTS: dict[Path, EnvironmentReader] = {}
 _PROJECT_ENVIRONMENTS_LOCK = RLock()
+
+_SECRET_QUOTES = {"\"", "'"}
+
+
+def secret_value(raw: str | None) -> str:
+    """Normalize one secret/token value; the single auth-credential contract.
+
+    Accidental surrounding whitespace/quotes from .env edits must not leak
+    into auth headers. Rules, in order: strip surrounding whitespace; strip
+    at most ONE leading and ONE trailing quote character (paired or not);
+    strip whitespace again.
+
+    Deliberate trade-off: the unpaired case — e.g. ``sk-test\"``, the common
+    .env typo — is normalized away, which also rewrites a legal token that
+    genuinely ends with a quote character. That risk is accepted: real API
+    keys/tokens do not start or end with quotes, while broken auth from a
+    stray quote fails with an opaque 401. Quote characters *inside* the
+    value (e.g. ``my\"pass\"word``) are never touched. Unlike the previous
+    chained ``strip(quote)`` — which peeled every leading/trailing quote
+    character, e.g. ``\"\"sk\"\"`` → ``sk`` — this contract peels at most
+    one per side and preserves inner structure.
+    """
+    value = str(raw or "").strip()
+    if value[:1] in _SECRET_QUOTES:
+        value = value[1:]
+    if value[-1:] in _SECRET_QUOTES:
+        value = value[:-1]
+    return value.strip()
 
 
 def venv_python(root: Path, name: str) -> Path:

--- a/config/settings.py
+++ b/config/settings.py
@@ -41,8 +41,7 @@ def _str(key: str, default: str = "", *, aliases: tuple[str, ...] = ()) -> str:
 
 def _secret(key: str, default: str = "", *, aliases: tuple[str, ...] = ()) -> str:
     """API keys/tokens: tolerate accidental surrounding quotes/whitespace from .env edits."""
-    value = _ENV.string(key, default, aliases=aliases)
-    return value.strip().strip('"').strip("'").strip()
+    return _ENV.secret(key, default, aliases=aliases)
 
 
 def declared_environment_fields():

--- a/config/settings.py
+++ b/config/settings.py
@@ -39,6 +39,12 @@ def _str(key: str, default: str = "", *, aliases: tuple[str, ...] = ()) -> str:
     return _ENV.string(key, default, aliases=aliases)
 
 
+def _secret(key: str, default: str = "", *, aliases: tuple[str, ...] = ()) -> str:
+    """API keys/tokens: tolerate accidental surrounding quotes/whitespace from .env edits."""
+    value = _ENV.string(key, default, aliases=aliases)
+    return value.strip().strip('"').strip("'").strip()
+
+
 def declared_environment_fields():
     """Return the schema discovered while this compatibility facade was built."""
 
@@ -77,21 +83,21 @@ if LLM_PROVIDER not in LLM_PROVIDERS:
         + ", ".join(sorted(LLM_PROVIDERS))
         + f"; observed {LLM_PROVIDER!r}"
     )
-DEEPSEEK_API_KEY   = _str("DEEPSEEK_API_KEY")
+DEEPSEEK_API_KEY   = _secret("DEEPSEEK_API_KEY")
 DEEPSEEK_BASE_URL  = _str("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
 DEEPSEEK_MODEL_NAME = _str("DEEPSEEK_MODEL_NAME", "deepseek-v4-flash")
 
 # ===========================================================================
 # LLM 提供商 — OpenAI / GPT
 # ===========================================================================
-OPENAI_API_KEY    = _str("OPENAI_API_KEY")
+OPENAI_API_KEY    = _secret("OPENAI_API_KEY")
 OPENAI_BASE_URL   = _str("OPENAI_BASE_URL", "https://api.openai.com/v1")
 OPENAI_MODEL_NAME = _str("OPENAI_MODEL_NAME", "gpt-5.4-mini")
 
 # ===========================================================================
 # LLM 提供商 — Gemini
 # ===========================================================================
-GEMINI_API_KEY    = _str("GEMINI_API_KEY")
+GEMINI_API_KEY    = _secret("GEMINI_API_KEY")
 GEMINI_MODEL_NAME = _str("GEMINI_MODEL_NAME", "gemini-2.5-flash")
 
 # ===========================================================================
@@ -264,7 +270,7 @@ VTS_RECONNECT_ENABLED = _bool("VTS_RECONNECT_ENABLED", True)
 # ===========================================================================
 TTS_BACKEND = _str("TTS_BACKEND", "gpt_sovits").strip().lower()
 TTS_API_BASE_URL = _str("TTS_API_BASE_URL", "https://api.openai.com/v1")
-TTS_API_KEY = _str("TTS_API_KEY", "")
+TTS_API_KEY = _secret("TTS_API_KEY", "")
 TTS_API_MODEL = _str("TTS_API_MODEL", "gpt-4o-mini-tts")
 TTS_API_VOICE = _str("TTS_API_VOICE", "alloy")
 TTS_API_STREAM_PROTOCOL = _str("TTS_API_STREAM_PROTOCOL", "buffered").strip().lower()
@@ -272,7 +278,7 @@ TTS_API_TIMEOUT_SECONDS = _float("TTS_API_TIMEOUT_SECONDS", 60.0)
 
 # MiMo TTS（小米远程后端，chat-completions 音频协议，非 /audio/speech）
 MIMO_TTS_BASE_URL = _str("MIMO_TTS_BASE_URL", "https://api.xiaomimimo.com/v1")
-MIMO_TTS_API_KEY = _str("MIMO_TTS_API_KEY", "")
+MIMO_TTS_API_KEY = _secret("MIMO_TTS_API_KEY", "")
 MIMO_TTS_MODEL = _str("MIMO_TTS_MODEL", "mimo-v2.5-tts")
 MIMO_TTS_VOICE = _str("MIMO_TTS_VOICE", "冰糖")
 
@@ -375,7 +381,7 @@ QWEN3_ASR_REQUIRE_CUDA = _bool("QWEN3_ASR_REQUIRE_CUDA", False)
 # 填入领域热词和指令；SenseVoice 后端会忽略此项
 ASR_CONTEXT = _str("ASR_CONTEXT", "")
 ASR_API_BASE_URL = _str("ASR_API_BASE_URL", "https://api.openai.com/v1")
-ASR_API_KEY = _str("ASR_API_KEY", "")
+ASR_API_KEY = _secret("ASR_API_KEY", "")
 ASR_API_MODEL = _str("ASR_API_MODEL", "gpt-4o-mini-transcribe")
 ASR_API_TIMEOUT_SECONDS = _float("ASR_API_TIMEOUT_SECONDS", 45.0)
 ASR_IDLE_UNLOAD_SECONDS = _float("ASR_IDLE_UNLOAD_SECONDS", 180.0)

--- a/server/browser_branch_planner.py
+++ b/server/browser_branch_planner.py
@@ -99,9 +99,9 @@ Output schema:
 def has_browser_branch_llm_config() -> bool:
     provider = _provider()
     if provider == "openai":
-        return bool(_env("OPENAI_API_KEY"))
+        return bool(_secret("OPENAI_API_KEY"))
     if provider == "deepseek":
-        return bool(_env("DEEPSEEK_API_KEY"))
+        return bool(_secret("DEEPSEEK_API_KEY"))
     return False
 
 
@@ -359,11 +359,11 @@ def _parse_json_object(text: str) -> dict[str, Any] | None:
 def _client(provider: str) -> OpenAI:
     if provider == "openai":
         return OpenAI(
-            api_key=_env("OPENAI_API_KEY"),
+            api_key=_secret("OPENAI_API_KEY"),
             base_url=_env("OPENAI_BASE_URL", "https://api.openai.com/v1"),
         )
     return OpenAI(
-        api_key=_env("DEEPSEEK_API_KEY"),
+        api_key=_secret("DEEPSEEK_API_KEY"),
         base_url=_env("DEEPSEEK_BASE_URL", "https://api.deepseek.com"),
     )
 
@@ -371,13 +371,13 @@ def _client(provider: str) -> OpenAI:
 def _provider() -> str:
     raw = _env("BROWSER_BRANCH_PROVIDER") or _env("LLM_PROVIDER", "deepseek")
     provider = raw.strip().lower()
-    if provider == "openai" and _env("OPENAI_API_KEY"):
+    if provider == "openai" and _secret("OPENAI_API_KEY"):
         return "openai"
-    if provider == "deepseek" and _env("DEEPSEEK_API_KEY"):
+    if provider == "deepseek" and _secret("DEEPSEEK_API_KEY"):
         return "deepseek"
-    if _env("DEEPSEEK_API_KEY"):
+    if _secret("DEEPSEEK_API_KEY"):
         return "deepseek"
-    if _env("OPENAI_API_KEY"):
+    if _secret("OPENAI_API_KEY"):
         return "openai"
     return provider
 
@@ -447,3 +447,8 @@ def _trim(text: str, limit: int) -> str:
 
 def _env(key: str, default: str = "") -> str:
     return _ENV.string(key, default)
+
+
+def _secret(key: str) -> str:
+    """API keys share the single auth-credential contract in config.environment."""
+    return _ENV.secret(key)

--- a/tests/test_secret_parsing.py
+++ b/tests/test_secret_parsing.py
@@ -1,0 +1,28 @@
+"""API key parsing tolerates accidental quotes/whitespace from .env edits."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_secret_settings_strip_accidental_quotes_and_whitespace() -> None:
+    probe = (
+        "import os;"
+        "os.environ['MIMO_TTS_API_KEY']='  \"sk-test123\"  ';"
+        "from config import settings;"
+        "assert settings.MIMO_TTS_API_KEY == 'sk-test123', repr(settings.MIMO_TTS_API_KEY);"
+        "print('SECRET_OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr[-1000:]
+    assert "SECRET_OK" in result.stdout

--- a/tests/test_secret_parsing.py
+++ b/tests/test_secret_parsing.py
@@ -1,22 +1,44 @@
-"""API key parsing tolerates accidental quotes/whitespace from .env edits."""
+"""API key parsing tolerates accidental quotes/whitespace from .env edits.
+
+Covers the single auth-credential contract in config.environment:
+settings, browser providers and provider command auth must observe the
+same normalized value for the same key.
+"""
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
+# Documented normalization rules (config.environment.secret_value):
+# whitespace stripped; at most one leading/trailing quote char removed
+# (paired or not — the .env typo case); inner quotes never touched.
+_RULE_CASES = [
+    ('  "sk-test123"  ', "sk-test123"),  # paired double quotes + whitespace
+    ("  'sk-test123'  ", "sk-test123"),  # paired single quotes + whitespace
+    ('sk-test"', "sk-test"),  # unpaired trailing quote (the reviewed typo)
+    ('"sk-test', "sk-test"),  # unpaired leading quote
+    ('" sk "\t', "sk"),  # quotes + inner whitespace
+    ('my"pass"word', 'my"pass"word'),  # inner quotes: legal token untouched
+    ("it's-a-token", "it's-a-token"),  # inner apostrophe untouched
+    ("   ", ""),  # whitespace-only -> empty (key counts as unconfigured)
+    ("sk-test123", "sk-test123"),  # clean value passes through
+]
 
-def test_secret_settings_strip_accidental_quotes_and_whitespace() -> None:
-    probe = (
-        "import os;"
-        "os.environ['MIMO_TTS_API_KEY']='  \"sk-test123\"  ';"
-        "from config import settings;"
-        "assert settings.MIMO_TTS_API_KEY == 'sk-test123', repr(settings.MIMO_TTS_API_KEY);"
-        "print('SECRET_OK')"
-    )
+
+def test_secret_value_normalization_rules() -> None:
+    probe = f"""
+from config.environment import secret_value
+cases = {_RULE_CASES!r}
+for raw, expected in cases:
+    got = secret_value(raw)
+    assert got == expected, (raw, got, expected)
+print("SECRET_RULES_OK")
+"""
     result = subprocess.run(
         [sys.executable, "-c", probe],
         cwd=ROOT,
@@ -25,4 +47,101 @@ def test_secret_settings_strip_accidental_quotes_and_whitespace() -> None:
         timeout=60,
     )
     assert result.returncode == 0, result.stderr[-1000:]
-    assert "SECRET_OK" in result.stdout
+    assert "SECRET_RULES_OK" in result.stdout
+
+
+def test_real_malformed_dotenv_three_consumers_agree(tmp_path) -> None:
+    """A real malformed .env yields one identical value for all three consumers."""
+    env_file = tmp_path / ".env"
+    env_file.write_text('DEEPSEEK_API_KEY=sk-from-dotenv"\n', encoding="utf-8")
+    probe = f"""
+import os
+from pathlib import Path
+tmp = Path({str(tmp_path)!r})
+assert "DEEPSEEK_API_KEY" not in os.environ
+
+# Real .env chain: parse the file into the process environment first, exactly
+# as a project .env reaches every consumer, then let the three consumers read.
+from dotenv import load_dotenv
+load_dotenv(tmp / ".env")
+
+from config import settings
+import server.browser_branch_planner as planner
+from tools.codex_provider_auth import provider_token
+consumed = (
+    settings.DEEPSEEK_API_KEY,
+    planner._secret("DEEPSEEK_API_KEY"),
+    provider_token(env_key="DEEPSEEK_API_KEY", env_file=tmp / ".env"),
+)
+assert consumed == ("sk-from-dotenv",) * 3, consumed
+print("SECRET_DOTENV_OK")
+"""
+    env = {k: v for k, v in os.environ.items() if k != "DEEPSEEK_API_KEY"}
+    result = subprocess.run(
+        [sys.executable, "-c", probe, str(tmp_path)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert "SECRET_DOTENV_OK" in result.stdout
+
+
+def test_process_env_overrides_dotenv_three_consumers_agree(tmp_path) -> None:
+    """A normalized process value keeps authority over .env for all consumers."""
+    env_file = tmp_path / ".env"
+    env_file.write_text('DEEPSEEK_API_KEY=sk-from-dotenv"\n', encoding="utf-8")
+    probe = f"""
+import os
+from pathlib import Path
+tmp = Path({str(tmp_path)!r})
+from dotenv import load_dotenv
+load_dotenv(tmp / ".env")
+
+os.environ["DEEPSEEK_API_KEY"] = '  "sk-from-process"  '
+from config import settings
+import server.browser_branch_planner as planner
+from tools.codex_provider_auth import provider_token
+consumed = (
+    settings.DEEPSEEK_API_KEY,
+    planner._secret("DEEPSEEK_API_KEY"),
+    provider_token(env_key="DEEPSEEK_API_KEY", env_file=tmp / ".env"),
+)
+assert consumed == ("sk-from-process",) * 3, consumed
+print("SECRET_PRIORITY_OK")
+"""
+    env = {k: v for k, v in os.environ.items() if k != "DEEPSEEK_API_KEY"}
+    result = subprocess.run(
+        [sys.executable, "-c", probe, str(tmp_path)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert "SECRET_PRIORITY_OK" in result.stdout
+
+
+def test_provider_token_still_prefers_process_environment(tmp_path) -> None:
+    """Existing authority contract for the command-auth tool is preserved."""
+    env_file = tmp_path / ".env"
+    env_file.write_text('DEEPSEEK_API_KEY=  "sk-dotenv"  \n', encoding="utf-8")
+    previous = os.environ.get("DEEPSEEK_API_KEY")
+    try:
+        os.environ["DEEPSEEK_API_KEY"] = ' "sk-process" '
+        from tools.codex_provider_auth import provider_token
+
+        assert provider_token(env_key="DEEPSEEK_API_KEY", env_file=env_file) == "sk-process"
+        # Whitespace-only process value normalizes to empty -> fall through.
+        os.environ["DEEPSEEK_API_KEY"] = "   "
+        assert provider_token(env_key="DEEPSEEK_API_KEY", env_file=env_file) == "sk-dotenv"
+        os.environ.pop("DEEPSEEK_API_KEY")
+        assert provider_token(env_key="DEEPSEEK_API_KEY", env_file=env_file) == "sk-dotenv"
+    finally:
+        if previous is None:
+            os.environ.pop("DEEPSEEK_API_KEY", None)
+        else:
+            os.environ["DEEPSEEK_API_KEY"] = previous

--- a/tools/codex_provider_auth.py
+++ b/tools/codex_provider_auth.py
@@ -10,19 +10,32 @@ import sys
 
 from dotenv import dotenv_values
 
+if str(Path(__file__).resolve().parents[1]) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from config.environment import secret_value
 
 _ENV_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def provider_token(*, env_key: str, env_file: Path) -> str:
+    """Resolve one provider credential: process env first, else ``env_file``.
+
+    Normalization is shared with config.environment (``secret_value``); the
+    read chain stays here on purpose because ``env_file`` is an explicit
+    Codex bridge input, not the project .env, so the project-level
+    ``load_project_environment`` singleton does not apply. Edge policy: a
+    process value that is empty/whitespace after normalization falls
+    through to ``env_file``; a missing/empty result everywhere is an error.
+    """
     key = str(env_key or "").strip()
     if not _ENV_KEY.fullmatch(key):
         raise ValueError("invalid provider credential environment variable name")
-    inherited = str(os.getenv(key) or "").strip()
+    inherited = secret_value(os.getenv(key))
     if inherited:
         return inherited
     values = dotenv_values(Path(env_file))
-    token = str(values.get(key) or "").strip()
+    token = secret_value(values.get(key))
     if not token:
         raise RuntimeError(f"provider credential {key} is not configured in Amadeus")
     return token


### PR DESCRIPTION
## 问题

`.env` 中 API key 末尾多一个引号（例如复制粘贴时带上的）会让鉴权串
变成畸形值，表现为 401 Unauthorized，报错完全不会指向引号这个原因，
排查成本很高。

## 修复

`config/settings.py` 新增 `_secret()` 读取器，六个 key
（DEEPSEEK / OPENAI / GEMINI / TTS / MIMO / ASR）统一去除首尾空白与
成对引号后使用。

## 测试

`tests/test_secret_parsing.py`：带引号+空白的 key 经 settings 读取后
等于干净值。

## 说明

该改动原在 #16 中，按评审意见拆出为独立 PR（与依赖分层无共同根因）。