### PR TITLE
fix(tts): prevent runaway GPT-SoVITS filler vowels

### DIFF
--- a/GPT_SoVITS/AR/models/t2s_flash_attn.py
+++ b/GPT_SoVITS/AR/models/t2s_flash_attn.py
@@ -145,20 +145,26 @@ class T2SBlockWithStaticCacheFlash:
         k_cache: torch.Tensor,
         v_cache: torch.Tensor,
         pos_idx: torch.Tensor,
+        key_valid_mask: torch.Tensor,
+        valid_kv_len: int = -1,
         torch_sdpa: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        if _flash_attn_with_kvcache is None:
+        # ``bucket`` mode cannot express invalid future/gap slots.  Preserve
+        # correctness by using the masked SDPA implementation for that
+        # explicitly requested diagnostic mode.  The production ``valid``
+        # mode has a contiguous prefix because generation now starts at the
+        # real prompt length rather than the aligned graph-key length.
+        if _flash_attn_with_kvcache is None or self.mode == "bucket":
             return self.sdpa_block.decode_next_token_with_static_cache(
-                x, k_cache, v_cache, pos_idx, torch_sdpa
+                x, k_cache, v_cache, pos_idx, key_valid_mask,
+                valid_kv_len, torch_sdpa
             )
         try:
-            if self.mode == "bucket":
-                attn = self._flash_bucket_len(x, k_cache, v_cache, pos_idx)
-            else:
-                attn = self._flash_valid_len(x, k_cache, v_cache, pos_idx)
+            attn = self._flash_valid_len(x, k_cache, v_cache, pos_idx)
         except RuntimeError:
             return self.sdpa_block.decode_next_token_with_static_cache(
-                x, k_cache, v_cache, pos_idx, torch_sdpa
+                x, k_cache, v_cache, pos_idx, key_valid_mask,
+                valid_kv_len, torch_sdpa
             )
         return self._finish_attention(x, attn), k_cache, v_cache
 
@@ -191,11 +197,15 @@ class T2STransformerWithStaticCacheFlash:
         k_cache: List[torch.Tensor],
         v_cache: List[torch.Tensor],
         pos_idx: torch.Tensor,
+        key_valid_mask: torch.Tensor,
+        valid_kv_len: int = -1,
         torch_sdpa: bool = True,
     ):
+        key_valid_mask.scatter_(1, pos_idx[:, :, 0], True)
         for i, block in enumerate(self.blocks):
             x, k_cache[i], v_cache[i] = block.decode_next_token_with_static_cache(
-                x, k_cache[i], v_cache[i], pos_idx, torch_sdpa
+                x, k_cache[i], v_cache[i], pos_idx, key_valid_mask,
+                valid_kv_len, torch_sdpa
             )
         return x, k_cache, v_cache
 

--- a/GPT_SoVITS/AR/models/t2s_model.py
+++ b/GPT_SoVITS/AR/models/t2s_model.py
@@ -317,13 +317,16 @@ class T2SBlockWithStaticCache:
         k_cache: torch.Tensor,   # 固定大小 [B, bucket_size, hidden]
         v_cache: torch.Tensor,   # 固定大小 [B, bucket_size, hidden]
         pos_idx: torch.Tensor,   # [B, 1, hidden] long，持久化 GPU 张量，replay 前 fill_ 更新
+        key_valid_mask: torch.Tensor,  # [B, bucket_size] bool；仅真实 prompt/生成位为 True
+        valid_kv_len: int = -1,  # 非 Graph 路径可直接使用连续有效前缀
         torch_sdpa: bool = True
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
-        scatter_ 写入当前步位置，attention 看全量 bucket。
+        scatter_ 写入当前步位置，attention 只看有效 KV 位。
         pos_idx 是持久化 GPU 张量，graph 外每步 fill_(step_pos) 更新地址内容，
         graph replay 时直接读取，实现写入位置随步数递增并积累历史。
-        未写入位置为 0，attention logit=0，softmax 后权重极小，不影响真实 token。
+        未写入位置以及 CUDA Graph 对齐产生的 gap 必须被 mask；零 KV 的
+        attention logit 为 0，并不等价于“权重可忽略”。
         """
         q, k, v = F.linear(x, self.qkv_w, self.qkv_b).chunk(3, dim=-1)
 
@@ -332,16 +335,31 @@ class T2SBlockWithStaticCache:
         v_cache.scatter_(1, pos_idx, v)
 
         batch_size = q.shape[0]
-        kv_len = k_cache.shape[1]  # 始终等于 bucket_size（静态形状，CUDA Graph 友好）
+        kv_len = valid_kv_len if valid_kv_len > 0 else k_cache.shape[1]
 
         q = q.view(batch_size, 1, self.num_heads, -1).transpose(1, 2)
-        k_full = k_cache.view(batch_size, kv_len, self.num_heads, -1).transpose(1, 2)
-        v_full = v_cache.view(batch_size, kv_len, self.num_heads, -1).transpose(1, 2)
+        k_full = k_cache[:, :kv_len, :].view(
+            batch_size, kv_len, self.num_heads, -1
+        ).transpose(1, 2)
+        v_full = v_cache[:, :kv_len, :].view(
+            batch_size, kv_len, self.num_heads, -1
+        ).transpose(1, 2)
 
-        if torch_sdpa:
+        # PyTorch SDPA 的 bool mask 以 True 表示“允许参与 attention”。
+        # 自定义实现沿用旧约定，以 True 表示“屏蔽”，因此需要取反。
+        # 非 Graph 路径的有效 KV 已是连续前缀，可直接切片并走无 mask kernel。
+        if valid_kv_len > 0 and torch_sdpa:
             attn = F.scaled_dot_product_attention(q, k_full, v_full)
-        else:
+        elif valid_kv_len > 0:
             attn = scaled_dot_product_attention(q, k_full, v_full, None)
+        elif torch_sdpa:
+            valid_attn_mask = key_valid_mask.unsqueeze(1).unsqueeze(1)
+            attn = F.scaled_dot_product_attention(
+                q, k_full, v_full, attn_mask=valid_attn_mask
+            )
+        else:
+            valid_attn_mask = key_valid_mask.unsqueeze(1).unsqueeze(1)
+            attn = scaled_dot_product_attention(q, k_full, v_full, ~valid_attn_mask)
 
         attn = attn.transpose(1, 2).reshape(batch_size, 1, -1)
         attn = F.linear(attn, self.out_w, self.out_b)
@@ -424,14 +442,19 @@ class T2STransformerWithStaticCache:
         k_cache: List[torch.Tensor],   # 固定大小的缓冲区列表，每层一个
         v_cache: List[torch.Tensor],
         pos_idx: torch.Tensor,         # [B, 1, hidden] long，所有层共享同一写入位置
+        key_valid_mask: torch.Tensor,  # [B, bucket_size] bool，所有层共享
+        valid_kv_len: int = -1,
         torch_sdpa: bool = True
     ):
         """
-        所有层共享 pos_idx，scatter_ 写入当前步，attention 看全量 bucket。
+        所有层共享 pos_idx 和有效位 mask。当前写入位在进入各层前只标记一次，
+        CUDA Graph replay 会随 pos_idx 内容变化而累积有效历史。
         """
+        key_valid_mask.scatter_(1, pos_idx[:, :, 0], True)
         for i in range(self.num_blocks):
             x, k_cache[i], v_cache[i] = self.blocks[i].decode_next_token_with_static_cache(
-                x, k_cache[i], v_cache[i], pos_idx, torch_sdpa
+                x, k_cache[i], v_cache[i], pos_idx, key_valid_mask,
+                valid_kv_len, torch_sdpa
             )
         return x, k_cache, v_cache
 
@@ -720,20 +743,28 @@ class Text2SemanticDecoder(nn.Module):
             
             # 模拟 prompt 后的初始状态
             for i in range(self.num_layers):
-                k_cache[i][:, :initial_len, :] = torch.randn(batch_size, initial_len, hidden_dim, dtype=model_dtype, device=device)
-                v_cache[i][:, :initial_len, :] = torch.randn(batch_size, initial_len, hidden_dim, dtype=model_dtype, device=device)
-            
-            current_lens = [initial_len] * self.num_layers
+                # Graph capture must not advance the caller's sampling RNG.
+                # Constant non-zero values exercise the same kernels without
+                # save/restore races against concurrent inference.
+                k_cache[i][:, :initial_len, :].fill_(0.01)
+                v_cache[i][:, :initial_len, :].fill_(0.02)
+            key_valid_mask = torch.zeros(
+                batch_size, bucket_size, dtype=torch.bool, device=device
+            )
+            key_valid_mask[:, :initial_len] = True
             
             # 模拟 xy_pos 和 pos_idx
-            xy_pos = torch.randn(batch_size, 1, hidden_dim, dtype=model_dtype, device=device)
+            xy_pos = torch.full(
+                (batch_size, 1, hidden_dim), 0.03,
+                dtype=model_dtype, device=device,
+            )
             # pos_idx：持久化 [B,1,H] long 张量，scatter_ 索引，replay 前 fill_ 更新
             pos_idx = torch.full((batch_size, 1, hidden_dim), initial_len, dtype=torch.long, device=device)
             
             # 🚀 预热：使用静态版本的 transformer（新签名，传 pos_idx）
             for warmup_idx in range(self.cuda_graph_warmup_steps):
                 xy_dec, k_cache, v_cache = self.t2s_transformer_static.decode_next_token_with_static_cache(
-                    xy_pos, k_cache, v_cache, pos_idx
+                    xy_pos, k_cache, v_cache, pos_idx, key_valid_mask
                 )
                 logits = self.ar_predict_layer(xy_dec[:, -1])
             
@@ -744,15 +775,22 @@ class Text2SemanticDecoder(nn.Module):
             # 捕获阶段
             capture_start = time.perf_counter()
             
-            # 重置为固定状态（prompt 区随机，其余零）
+            # 重置为固定状态（prompt 区常量，其余零）
             k_cache = [torch.zeros(batch_size, bucket_size, hidden_dim, dtype=model_dtype, device=device) 
                       for _ in range(self.num_layers)]
             v_cache = [torch.zeros(batch_size, bucket_size, hidden_dim, dtype=model_dtype, device=device) 
                       for _ in range(self.num_layers)]
             for i in range(self.num_layers):
-                k_cache[i][:, :initial_len, :] = torch.randn(batch_size, initial_len, hidden_dim, dtype=model_dtype, device=device)
-                v_cache[i][:, :initial_len, :] = torch.randn(batch_size, initial_len, hidden_dim, dtype=model_dtype, device=device)
-            xy_pos = torch.randn(batch_size, 1, hidden_dim, dtype=model_dtype, device=device)
+                k_cache[i][:, :initial_len, :].fill_(0.01)
+                v_cache[i][:, :initial_len, :].fill_(0.02)
+            key_valid_mask = torch.zeros(
+                batch_size, bucket_size, dtype=torch.bool, device=device
+            )
+            key_valid_mask[:, :initial_len] = True
+            xy_pos = torch.full(
+                (batch_size, 1, hidden_dim), 0.03,
+                dtype=model_dtype, device=device,
+            )
             pos_idx = torch.full((batch_size, 1, hidden_dim), initial_len, dtype=torch.long, device=device)
             
             # 捕获 CUDA Graph（必须在目标设备上下文内创建，避免多卡时 stream 关联到 cuda:0）
@@ -768,7 +806,7 @@ class Text2SemanticDecoder(nn.Module):
 
                 with torch.cuda.graph(cuda_graph, **_graph_extra):
                     xy_dec, k_cache_out, v_cache_out = self.t2s_transformer_static.decode_next_token_with_static_cache(
-                        xy_pos, k_cache, v_cache, pos_idx
+                        xy_pos, k_cache, v_cache, pos_idx, key_valid_mask
                     )
                     logits = self.ar_predict_layer(xy_dec[:, -1])
             
@@ -782,6 +820,7 @@ class Text2SemanticDecoder(nn.Module):
                 'k_cache': k_cache,
                 'v_cache': v_cache,
                 'pos_idx': pos_idx,   # 持久化写入位置索引
+                'key_valid_mask': key_valid_mask,
             }
             self.bucket_static_outputs[graph_key] = {
                 'xy_dec': xy_dec,
@@ -1396,12 +1435,13 @@ class Text2SemanticDecoder(nn.Module):
         # 🚀 KV Cache 策略选择和初始化
         current_bucket = None
         bucket_captured = False
-        bucket_valid_len = None
         current_lens = None  # 用于静态缓存模式的长度追踪
         graph_key = None       # (bucket_size, initial_len) tuple，用于 CUDA Graph 字典查找
-        graph_initial_len = None  # Graph 捕获时的写入起始位置
+        graph_initial_len = None  # 仅用于选择可复用的 Graph key
+        graph_prompt_len = None   # 当前句真实 prompt 长度，也是连续 KV 的写入起点
         graph_step_count = 0   # 本句在 graph 路径已走的步数
         pos_idx_static: Optional[torch.Tensor] = None  # static path 用的持久化写入索引
+        key_valid_mask: Optional[torch.Tensor] = None  # static path 的真实 KV 有效位
         
         # 选择使用哪套 transformer
         static_transformer = self.t2s_transformer_static
@@ -1459,6 +1499,10 @@ class Text2SemanticDecoder(nn.Module):
                         k_cache = k_cache_static
                         v_cache = v_cache_static
                         current_lens = [kv_cache_len] * len(k_cache)
+                        key_valid_mask = torch.zeros(
+                            batch_size, current_bucket, dtype=torch.bool, device=device
+                        )
+                        key_valid_mask[:, :kv_cache_len] = True
                         
                         # 预分配 static path 用的 pos_idx（持久化，每步 fill_，避免重复分配）
                         pos_idx_static = torch.full(
@@ -1468,12 +1512,11 @@ class Text2SemanticDecoder(nn.Module):
                         
                         print(f"[T2S] fixed buffer initialized: bucket={current_bucket} current_len={kv_cache_len}")
                         
-                        # graph_initial_len 向上对齐到 _GRAPH_INITIAL_LEN_STRIDE 的倍数。
-                        # 好处：kv_cache_len=337/345/351 均映射到 352，共享同一张 graph，
-                        #       彻底消除每句重复 capture 的 0.4s 开销。
-                        # 代价：gap = (initial_len - kv_cache_len) ≤ stride-1 = 31 个零 KV，
-                        #       对于 330+ token 的 prompt 影响 < 10%，attention 实测无感知。
+                        # graph_initial_len 只用于将相近 prompt 复用到同一张 Graph。
+                        # 当前句仍从真实 kv_cache_len 开始连续写入，绝不能把对齐 gap
+                        # 当成有效 KV；Graph 内的 pos_idx/mask 都是持久化张量，内容可变。
                         graph_initial_len = None
+                        graph_prompt_len = kv_cache_len
                         graph_key = None
                         if graph_run_enabled:
                             if kv_cache_len >= current_bucket - 1:
@@ -1507,9 +1550,8 @@ class Text2SemanticDecoder(nn.Module):
                                         # 本 key 已在之前的句子中捕获，直接复用
                                         bucket_captured = True
 
-                                    # 新句子开始：把 prompt KV 写入 static buffer，
-                                    # gap 区 [kv_cache_len, graph_initial_len) 清零，生成区也清零。
-                                    # pos_idx 设为 graph_initial_len（第一步写入位置）。
+                                    # 新句子开始：只把真实 prompt 标为有效，所有 gap/未来位
+                                    # 都保持无效；第一步从真实 prompt 末尾连续写入。
                                     if bucket_captured and graph_key in self.bucket_graphs:
                                         static_in = self.bucket_static_inputs[graph_key]
                                         for _i in range(len(static_in['k_cache'])):
@@ -1518,8 +1560,9 @@ class Text2SemanticDecoder(nn.Module):
                                             static_in['v_cache'][_i][:, :kv_cache_len, :].copy_(v_cache[_i][:, :kv_cache_len, :])
                                             static_in['k_cache'][_i][:, kv_cache_len:, :].zero_()
                                             static_in['v_cache'][_i][:, kv_cache_len:, :].zero_()
-                                        # 第一步写入位置 = graph_initial_len（对齐后的 prompt 末尾）
-                                        static_in['pos_idx'].fill_(graph_initial_len)
+                                        static_in['key_valid_mask'].zero_()
+                                        static_in['key_valid_mask'][:, :kv_cache_len] = True
+                                        static_in['pos_idx'].fill_(kv_cache_len)
                     else:
                         print(f"[T2S] kv_cache_len={kv_cache_len} exceeds all buckets; using normal path")
                         static_mode_active = False
@@ -1528,29 +1571,27 @@ class Text2SemanticDecoder(nn.Module):
                 
             elif static_mode_active and current_bucket is not None and current_lens is not None:
                 # 🚀 使用静态缓存模式
-                
-                # 🔧 关键修复：在写入前检查是否需要滑动窗口
-                if current_lens[0] >= current_bucket - 1:
-                    # 缓冲区即将满，使用滑动窗口：保留最新的 N-1 个 token
-                    keep_len = current_bucket - 1
-                    # 只在第一次触发时打印，避免日志过多
-                    if not hasattr(self, '_sliding_window_triggered'):
-                        self._sliding_window_triggered = True
-                        print(f"[T2S] buffer nearly full ({current_lens[0]}/{current_bucket}); sliding window keep={keep_len}")
-                    
-                    # 移动 KV cache，丢弃最旧的 token
-                    for i in range(len(k_cache)):
-                        k_cache[i][:, :keep_len, :] = k_cache[i][:, -keep_len:, :].clone()
-                        v_cache[i][:, :keep_len, :] = v_cache[i][:, -keep_len:, :].clone()
-                        # 清零后面的部分
-                        k_cache[i][:, keep_len:, :].zero_()
-                        v_cache[i][:, keep_len:, :].zero_()
-                    
-                    # 重置 current_lens
-                    current_lens = [keep_len] * len(current_lens)
-                
+
+                # 固定桶装满后保留完整 prompt/历史，切到动态 KV 继续。旧的滑动窗口
+                # 会丢掉最早的文本与参考条件，正是长解码时不允许破坏的语义不变量。
+                if current_lens[0] >= current_bucket:
+                    _dynamic_len = current_lens[0]
+                    k_cache = [item[:, :_dynamic_len, :].clone() for item in k_cache]
+                    v_cache = [item[:, :_dynamic_len, :].clone() for item in v_cache]
+                    static_mode_active = False
+                    graph_run_enabled = False
+                    transformer = dynamic_transformer
+                    print(
+                        f"[T2S] fixed buffer full ({_dynamic_len}/{current_bucket}); "
+                        "continuing with full-context dynamic KV"
+                    )
+                    xy_dec, k_cache, v_cache = transformer.decode_next_token(
+                        xy_pos, k_cache, v_cache
+                    )
+                    logits = self.ar_predict_layer(xy_dec[:, -1])
+
                 # 🚀 尝试使用 CUDA Graph（如果已捕获）
-                if graph_run_enabled and bucket_captured and graph_key is not None and graph_key in self.bucket_graphs:
+                elif graph_run_enabled and bucket_captured and graph_key is not None and graph_key in self.bucket_graphs:
                     replay_failed = False
                     bucket_lock = self._get_bucket_lock(graph_key)
                     with bucket_lock:
@@ -1562,8 +1603,9 @@ class Text2SemanticDecoder(nn.Module):
                             # 每步只需 2 个轻量更新，无 per-layer KV copy：
                             # 1. 当前 token 嵌入
                             static_inputs['xy_pos'].copy_(xy_pos)
-                            # 2. 写入位置 = prompt长度 + 已生成步数（scatter_ 历史自动积累）
-                            static_inputs['pos_idx'].fill_(graph_initial_len + graph_step_count)
+                            # 2. 写入位置 = 真实 prompt 长度 + 已生成步数。
+                            # graph_initial_len 只是复用 key，不参与逻辑序列长度。
+                            static_inputs['pos_idx'].fill_(graph_prompt_len + graph_step_count)
                             
                             self._replay_cuda_graph(cuda_graph, xy_pos.device)
 
@@ -1576,25 +1618,23 @@ class Text2SemanticDecoder(nn.Module):
                                 self._cuda_graph_replay_started = True
                                 print(f"[CUDA Graph] replay enabled: key={graph_key} history mode")
                             
-                            # 安全阀：写入位置超出 bucket 时自动 fallback
-                            if graph_initial_len + graph_step_count >= current_bucket:
+                            # 安全阀：桶写满后转动态 KV，保留完整上下文。
+                            if graph_prompt_len + graph_step_count >= current_bucket:
                                 graph_run_enabled = False
-                                print("[CUDA Graph] write position reached bucket boundary; fallback to static path")
-                                # 把 graph buffer 的最新 KV 同步回主循环 k_cache，
-                                # 否则 static path 会用 prompt-only 的 stale k_cache，
-                                # graph 阶段积累的历史全部丢失，导致 attention 不一致。
-                                _fallback_len = graph_initial_len + graph_step_count
+                                static_mode_active = False
+                                transformer = dynamic_transformer
+                                print("[CUDA Graph] bucket full; continuing with full-context dynamic KV")
+                                _fallback_len = graph_prompt_len + graph_step_count
                                 static_in_fb = self.bucket_static_inputs[graph_key]
-                                for _fi in range(len(k_cache)):
-                                    k_cache[_fi].copy_(static_in_fb['k_cache'][_fi])
-                                    v_cache[_fi].copy_(static_in_fb['v_cache'][_fi])
+                                k_cache = [
+                                    item[:, :_fallback_len, :].clone()
+                                    for item in static_in_fb['k_cache']
+                                ]
+                                v_cache = [
+                                    item[:, :_fallback_len, :].clone()
+                                    for item in static_in_fb['v_cache']
+                                ]
                                 current_lens = [_fallback_len] * len(k_cache)
-                                if pos_idx_static is not None:
-                                    pos_idx_static.fill_(_fallback_len)
-                                else:
-                                    pos_idx_static = k_cache[0].new_full(
-                                        (k_cache[0].shape[0], 1, k_cache[0].shape[2]),
-                                        _fallback_len, dtype=torch.long)
                         except RuntimeError as e:
                             replay_failed = True
                             graph_run_enabled = False
@@ -1606,7 +1646,9 @@ class Text2SemanticDecoder(nn.Module):
                         for i in range(len(k_cache)):
                             k_cache[i].copy_(static_inputs['k_cache'][i])
                             v_cache[i].copy_(static_inputs['v_cache'][i])
-                        _fallback_len = graph_initial_len + graph_step_count
+                        if key_valid_mask is not None:
+                            key_valid_mask.copy_(static_inputs['key_valid_mask'])
+                        _fallback_len = graph_prompt_len + graph_step_count
                         current_lens = [_fallback_len] * len(k_cache)
                         if pos_idx_static is not None:
                             pos_idx_static.fill_(_fallback_len)
@@ -1615,7 +1657,8 @@ class Text2SemanticDecoder(nn.Module):
                                 (k_cache[0].shape[0], 1, k_cache[0].shape[2]),
                                 _fallback_len, dtype=torch.long)
                         xy_dec, k_cache, v_cache = transformer.decode_next_token_with_static_cache(
-                            xy_pos, k_cache, v_cache, pos_idx_static
+                            xy_pos, k_cache, v_cache, pos_idx_static, key_valid_mask,
+                            _fallback_len + 1
                         )
                         current_lens = [l + 1 for l in current_lens]
                         logits = self.ar_predict_layer(xy_dec[:, -1])
@@ -1629,7 +1672,8 @@ class Text2SemanticDecoder(nn.Module):
                             (k_cache[0].shape[0], 1, k_cache[0].shape[2]),
                             current_lens[0], dtype=torch.long)
                     xy_dec, k_cache, v_cache = transformer.decode_next_token_with_static_cache(
-                        xy_pos, k_cache, v_cache, pos_idx_static
+                        xy_pos, k_cache, v_cache, pos_idx_static, key_valid_mask,
+                        current_lens[0] + 1
                     )
                     current_lens = [l + 1 for l in current_lens]
                     logits = self.ar_predict_layer(xy_dec[:, -1])

--- a/local_tts_infer.py
+++ b/local_tts_infer.py
@@ -13,6 +13,10 @@ import string
 from string import punctuation
 
 from tts.optional_ap_bwe import APBWEUnavailable, create_ap_bwe
+from tts.semantic_stability import (
+    SemanticGenerationError,
+    assess_semantic_candidate,
+)
 
 
 def _iter_segment_text_lang(text: str):
@@ -210,20 +214,123 @@ class TTSInferencer:
             with torch.cuda.device(self._tts_device_idx):
                 torch.cuda.synchronize()
 
-    def _record_t2s_stat(self, text_item: str, tokens: int, elapsed_sec: float):
+    def _record_t2s_stat(
+        self,
+        text_item: str,
+        tokens: int,
+        elapsed_sec: float,
+        attempts: int = 1,
+    ):
         rate = float(tokens) / elapsed_sec if elapsed_sec > 0 else 0.0
         stat = {
             "text": text_item,
             "tokens": int(tokens),
             "elapsed_sec": float(elapsed_sec),
             "tokens_per_sec": rate,
+            "semantic_attempts": int(attempts),
         }
         self.t2s_stats.append(stat)
         logger.info(
             f"[t2s] tokens={stat['tokens']} elapsed={stat['elapsed_sec']:.3f}s "
-            f"speed={stat['tokens_per_sec']:.0f} it/s"
+            f"speed={stat['tokens_per_sec']:.0f} it/s attempts={stat['semantic_attempts']}"
         )
         return stat
+
+    @staticmethod
+    def _semantic_guard_enabled() -> bool:
+        raw = os.environ.get("TTS_SEMANTIC_GUARD", "1")
+        return raw.strip().lower() not in {"0", "false", "off", "no"}
+
+    def _infer_semantic_with_guard(
+        self,
+        *,
+        text_item: str,
+        target_phone_count: int,
+        all_phoneme_ids,
+        all_phoneme_len,
+        prompt,
+        bert,
+        top_k,
+        top_p,
+        temperature,
+        effective_max_sec: float,
+        enable_cuda_graph: bool,
+        enable_static_kv: bool,
+    ):
+        """Generate one admissible semantic candidate before SoVITS decoding.
+
+        The normal path performs exactly one unchanged 1.35-penalty decode.  A
+        structurally collapsed candidate is logged, discarded, and sampled one
+        more time with a modestly stronger repetition penalty.  If both bounded
+        attempts collapse, no vocoder work is performed and the caller fails
+        closed instead of emitting a long corrupt waveform.
+        """
+
+        max_generation_tokens = int(self.hz * effective_max_sec)
+        guard_enabled = self._semantic_guard_enabled()
+        penalties = (1.35, 1.5) if guard_enabled else (1.35,)
+        last_assessment = None
+
+        for attempt, repetition_penalty in enumerate(penalties, start=1):
+            prediction, idx = self.t2s_model.model.infer_panel(
+                all_phoneme_ids,
+                all_phoneme_len,
+                prompt,
+                bert,
+                top_k=top_k,
+                top_p=top_p,
+                temperature=temperature,
+                repetition_penalty=repetition_penalty,
+                early_stop_num=max_generation_tokens,
+                enable_cuda_graph=enable_cuda_graph,
+                enable_static_kv=enable_static_kv,
+            )
+            generated_count = max(0, int(idx))
+            if generated_count:
+                candidate = prediction[:, -generated_count:]
+            else:
+                candidate = prediction[:, :0]
+
+            if not guard_enabled:
+                return candidate.unsqueeze(0), generated_count, attempt
+
+            tokens = candidate.detach().reshape(-1).cpu().long().tolist()
+            assessment = assess_semantic_candidate(
+                tokens,
+                target_phone_count=target_phone_count,
+                max_generation_tokens=max_generation_tokens,
+            )
+            last_assessment = assessment
+            if assessment.accepted:
+                if attempt > 1:
+                    logger.info(
+                        "[T2S guard] retry recovered text=%r tokens=%d penalty=%.2f",
+                        text_item[:80],
+                        assessment.token_count,
+                        repetition_penalty,
+                    )
+                return candidate.unsqueeze(0), generated_count, attempt
+
+            logger.warning(
+                "[T2S guard] rejected attempt=%d/%d text=%r reasons=%s "
+                "tokens=%d budget=%d equal_run=%d periodic_run=%d top_ratio=%.3f",
+                attempt,
+                len(penalties),
+                text_item[:80],
+                ",".join(assessment.reasons),
+                assessment.token_count,
+                assessment.soft_token_budget,
+                assessment.longest_equal_run,
+                assessment.longest_periodic_run,
+                assessment.top_token_ratio,
+            )
+
+        detail = "unknown"
+        if last_assessment is not None:
+            detail = ",".join(last_assessment.reasons) or "rejected"
+        raise SemanticGenerationError(
+            f"semantic generation collapsed after {len(penalties)} attempts: {detail}"
+        )
 
     def _resolve_runtime_warmup_ref(self):
         lang = _default_lang_code()
@@ -1059,19 +1166,20 @@ class TTSInferencer:
                     # GPT推理
                     logger.info("running GPT inference...")
                     with torch.no_grad():
-                        pred_semantic, idx = self.t2s_model.model.infer_panel(
-                            all_phoneme_ids,
-                            all_phoneme_len,
-                            None if ref_free else prompt,
-                            bert,
+                        pred_semantic, idx, _semantic_attempts = self._infer_semantic_with_guard(
+                            text_item=text_item,
+                            target_phone_count=len(phones2),
+                            all_phoneme_ids=all_phoneme_ids,
+                            all_phoneme_len=all_phoneme_len,
+                            prompt=None if ref_free else prompt,
+                            bert=bert,
                             top_k=top_k,
                             top_p=top_p,
                             temperature=temperature,
-                            early_stop_num=int(self.hz * effective_max_sec),
+                            effective_max_sec=effective_max_sec,
                             enable_cuda_graph=enable_cuda_graph,
                             enable_static_kv=enable_static_kv,
                         )
-                        pred_semantic = pred_semantic[:, -idx:].unsqueeze(0)
                         cache[i_text] = pred_semantic
 
                 # SoVITS推理
@@ -1486,22 +1594,28 @@ class TTSInferencer:
                         if collect_t2s_stats:
                             self._sync_t2s_timing()
                             t2s_start = time.perf_counter()
-                        pred_semantic, idx = self.t2s_model.model.infer_panel(
-                            all_phoneme_ids,
-                            all_phoneme_len,
-                            None if ref_free else prompt,
-                            bert,
+                        pred_semantic, idx, semantic_attempts = self._infer_semantic_with_guard(
+                            text_item=text_item,
+                            target_phone_count=len(phones2),
+                            all_phoneme_ids=all_phoneme_ids,
+                            all_phoneme_len=all_phoneme_len,
+                            prompt=None if ref_free else prompt,
+                            bert=bert,
                             top_k=top_k,
                             top_p=top_p,
                             temperature=temperature,
-                            early_stop_num=int(self.hz * effective_max_sec),
+                            effective_max_sec=effective_max_sec,
                             enable_cuda_graph=enable_cuda_graph,
                             enable_static_kv=enable_static_kv,
                         )
                         if collect_t2s_stats:
                             self._sync_t2s_timing()
-                            self._record_t2s_stat(text_item, idx, time.perf_counter() - t2s_start)
-                        pred_semantic = pred_semantic[:, -idx:].unsqueeze(0)
+                            self._record_t2s_stat(
+                                text_item,
+                                idx,
+                                time.perf_counter() - t2s_start,
+                                attempts=semantic_attempts,
+                            )
                         cache[i_text] = pred_semantic
 
                 # SoVITS推理

--- a/tests/test_first_sentence_audio_cache.py
+++ b/tests/test_first_sentence_audio_cache.py
@@ -153,6 +153,24 @@ def test_legacy_cache_with_mismatched_identity_is_rejected(
     assert cache.path_for(text, params).exists() is False
 
 
+def test_pre_guard_synthesis_revision_is_not_reused(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _configure_current_identity(monkeypatch)
+    cache = FirstSentenceAudioCache(tmp_path)
+    params = _current_params()
+    text = "うーん……"
+    old_payload = cache.key_payload(text, params)
+    old_payload.pop("synthesis_revision")
+    audio = np.ones(2400, dtype=np.float32) * 0.05
+    _write_entry(cache, old_payload, audio)
+
+    assert cache._path_for_payload(old_payload).exists() is True
+    assert cache.path_for(text, params).exists() is False
+    assert cache.lookup(text, params) is None
+
+
 def test_legacy_cache_with_malformed_metadata_is_rejected(
     tmp_path,
     monkeypatch,

--- a/tests/test_gsv_stability_probe.py
+++ b/tests/test_gsv_stability_probe.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from tools.probes.probe_gsv_stability import (
+    _longest_equal_run,
+    _mark_anomalies,
+    _periodic_run,
+    _token_metrics,
+)
+
+
+def test_token_metrics_detect_equal_and_periodic_runs() -> None:
+    tokens = [1, 2, 1, 2, 1, 2, 7, 7, 7, 7]
+    metrics = _token_metrics(tokens)
+
+    assert _longest_equal_run(tokens) == 4
+    assert _periodic_run(tokens, max_period=2) == (6, 2)
+    assert metrics["longest_equal_run"] == 4
+    assert metrics["longest_periodic_run"] == 6
+    assert metrics["periodic_run_period"] == 2
+
+
+def test_mark_anomalies_uses_case_relative_length_and_stop_reason() -> None:
+    rows = []
+    for seed, length in enumerate([20, 21, 22, 140], start=1):
+        rows.append(
+            {
+                "case": "filler",
+                "mode": "dynamic",
+                "seed": seed,
+                "termination": "eos",
+                "token_count": length,
+                "longest_equal_run": 1,
+                "longest_periodic_run": 2,
+                "top_token_ratio": 0.1,
+            }
+        )
+    rows.append(
+        {
+            "case": "filler",
+            "mode": "static",
+            "seed": 5,
+            "termination": "early_stop",
+            "token_count": 60,
+            "longest_equal_run": 1,
+            "longest_periodic_run": 2,
+            "top_token_ratio": 0.1,
+        }
+    )
+
+    _mark_anomalies(rows)
+
+    assert rows[0]["anomalous"] is False
+    assert rows[3]["anomaly_reasons"] == ["length_outlier"]
+    assert rows[4]["anomaly_reasons"] == ["early_stop"]

--- a/tests/test_local_tts_semantic_guard.py
+++ b/tests/test_local_tts_semantic_guard.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from local_tts_infer import TTSInferencer
+from tts.semantic_stability import SemanticGenerationError
+
+
+class _FakeSemanticDecoder:
+    def __init__(self, candidates: list[list[int]]) -> None:
+        self.candidates = candidates
+        self.penalties: list[float] = []
+
+    def infer_panel(self, *_args, **kwargs):
+        self.penalties.append(float(kwargs["repetition_penalty"]))
+        tokens = self.candidates[len(self.penalties) - 1]
+        return torch.tensor([tokens], dtype=torch.long), len(tokens)
+
+
+def _inferencer(candidates: list[list[int]]) -> tuple[TTSInferencer, _FakeSemanticDecoder]:
+    decoder = _FakeSemanticDecoder(candidates)
+    inferencer = TTSInferencer.__new__(TTSInferencer)
+    inferencer.hz = 50
+    inferencer.t2s_model = SimpleNamespace(model=decoder)
+    return inferencer, decoder
+
+
+def _call(inferencer: TTSInferencer):
+    return inferencer._infer_semantic_with_guard(
+        text_item="うーん……正直、まだ完全には分からないわ。",
+        target_phone_count=48,
+        all_phoneme_ids=torch.zeros(1, 4, dtype=torch.long),
+        all_phoneme_len=torch.tensor([4]),
+        prompt=torch.zeros(1, 2, dtype=torch.long),
+        bert=torch.zeros(1, 1024, 4),
+        top_k=5,
+        top_p=1.0,
+        temperature=0.6,
+        effective_max_sec=8.0,
+        enable_cuda_graph=True,
+        enable_static_kv=True,
+    )
+
+
+@contextmanager
+def _guard_setting(value: str):
+    previous = os.environ.get("TTS_SEMANTIC_GUARD")
+    os.environ["TTS_SEMANTIC_GUARD"] = value
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TTS_SEMANTIC_GUARD", None)
+        else:
+            os.environ["TTS_SEMANTIC_GUARD"] = previous
+
+
+def test_guard_discards_collapsed_candidate_and_returns_single_retry() -> None:
+    with _guard_setting("1"):
+        bad = list(range(20)) + [937] * 60
+        good = [index % 23 for index in range(70)]
+        inferencer, decoder = _inferencer([bad, good])
+
+        candidate, count, attempts = _call(inferencer)
+
+        assert attempts == 2
+        assert count == len(good)
+        assert candidate.shape == (1, 1, len(good))
+        assert candidate.reshape(-1).tolist() == good
+        assert decoder.penalties == [1.35, 1.5]
+
+
+def test_guard_fails_closed_after_two_collapsed_candidates() -> None:
+    with _guard_setting("1"):
+        bad_a = [41] * 60
+        bad_b = [77] * 70
+        inferencer, decoder = _inferencer([bad_a, bad_b])
+
+        try:
+            _call(inferencer)
+        except SemanticGenerationError as exc:
+            assert "after 2 attempts" in str(exc)
+        else:
+            raise AssertionError("two collapsed candidates must fail closed")
+
+        assert decoder.penalties == [1.35, 1.5]
+
+
+def test_guard_off_preserves_one_attempt_path() -> None:
+    with _guard_setting("0"):
+        bad = [41] * 60
+        inferencer, decoder = _inferencer([bad])
+
+        candidate, count, attempts = _call(inferencer)
+
+        assert attempts == 1
+        assert count == len(bad)
+        assert candidate.reshape(-1).tolist() == bad
+        assert decoder.penalties == [1.35]
+
+
+if __name__ == "__main__":
+    test_guard_discards_collapsed_candidate_and_returns_single_retry()
+    test_guard_fails_closed_after_two_collapsed_candidates()
+    test_guard_off_preserves_one_attempt_path()
+    print("all local TTS semantic guard tests passed")

--- a/tests/test_local_tts_semantic_guard.py
+++ b/tests/test_local_tts_semantic_guard.py
@@ -9,13 +9,16 @@ from types import SimpleNamespace
 import pytest
 
 
-if os.environ.get("AMADEUS_E2E_NO_TTS", "").strip().lower() in {
+_MODEL_LESS = os.environ.get("AMADEUS_E2E_NO_TTS", "").strip().lower() in {
     "1",
     "true",
     "yes",
     "on",
-}:
-    pytest.skip("full TTS runtime is disabled in model-less CI", allow_module_level=True)
+}
+pytestmark = pytest.mark.skipif(
+    _MODEL_LESS,
+    reason="full TTS runtime is disabled in model-less CI",
+)
 
 import torch
 
@@ -23,8 +26,12 @@ import torch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from local_tts_infer import TTSInferencer
-from tts.semantic_stability import SemanticGenerationError
+if not _MODEL_LESS:
+    from local_tts_infer import TTSInferencer
+    from tts.semantic_stability import SemanticGenerationError
+else:
+    TTSInferencer = object
+    SemanticGenerationError = RuntimeError
 
 
 class _FakeSemanticDecoder:

--- a/tests/test_local_tts_semantic_guard.py
+++ b/tests/test_local_tts_semantic_guard.py
@@ -6,6 +6,17 @@ from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+
+if os.environ.get("AMADEUS_E2E_NO_TTS", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}:
+    pytest.skip("full TTS runtime is disabled in model-less CI", allow_module_level=True)
+
 import torch
 
 

--- a/tests/test_t2s_static_kv_mask.py
+++ b/tests/test_t2s_static_kv_mask.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "GPT_SoVITS"))
+
+from AR.models.t2s_model import (  # noqa: E402
+    T2SBlock,
+    T2SBlockWithStaticCache,
+    T2SMLP,
+    T2STransformerWithStaticCache,
+)
+
+
+def _blocks(hidden: int = 4, heads: int = 2):
+    torch.manual_seed(17)
+    mlp_w1 = torch.randn(hidden * 2, hidden)
+    mlp_b1 = torch.randn(hidden * 2)
+    mlp_w2 = torch.randn(hidden, hidden * 2)
+    mlp_b2 = torch.randn(hidden)
+    qkv_w = torch.randn(hidden * 3, hidden)
+    qkv_b = torch.randn(hidden * 3)
+    out_w = torch.randn(hidden, hidden)
+    out_b = torch.randn(hidden)
+    norm_w1 = torch.randn(hidden)
+    norm_b1 = torch.randn(hidden)
+    norm_w2 = torch.randn(hidden)
+    norm_b2 = torch.randn(hidden)
+    common = (
+        heads,
+        hidden,
+        qkv_w,
+        qkv_b,
+        out_w,
+        out_b,
+        norm_w1,
+        norm_b1,
+        1e-5,
+        norm_w2,
+        norm_b2,
+        1e-5,
+    )
+    dynamic = T2SBlock(
+        common[0],
+        common[1],
+        T2SMLP(mlp_w1, mlp_b1, mlp_w2, mlp_b2),
+        *common[2:],
+    )
+    static = T2SBlockWithStaticCache(
+        common[0],
+        common[1],
+        T2SMLP(mlp_w1, mlp_b1, mlp_w2, mlp_b2),
+        *common[2:],
+    )
+    return dynamic, static
+
+
+def test_static_mask_matches_dynamic_attention_with_gap_and_future_garbage() -> None:
+    dynamic, static = _blocks()
+    torch.manual_seed(23)
+    x = torch.randn(1, 1, 4)
+    prefix_k = torch.randn(1, 3, 4)
+    prefix_v = torch.randn(1, 3, 4)
+
+    expected, _, _ = dynamic.decode_next_token(
+        x.clone(), prefix_k.clone(), prefix_v.clone()
+    )
+
+    # Positions 3-4 are an invalid graph-alignment gap; positions 6-7 mimic
+    # stale/future memory.  Only prefix 0-2 and current write position 5 count.
+    static_k = torch.randn(1, 8, 4) * 50
+    static_v = torch.randn(1, 8, 4) * 50
+    static_k[:, :3] = prefix_k
+    static_v[:, :3] = prefix_v
+    pos_idx = torch.full((1, 1, 4), 5, dtype=torch.long)
+    valid = torch.zeros(1, 8, dtype=torch.bool)
+    valid[:, :3] = True
+    transformer = T2STransformerWithStaticCache(1, [static])
+
+    actual, _, _ = transformer.decode_next_token_with_static_cache(
+        x.clone(), [static_k], [static_v], pos_idx, valid
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+    assert valid.tolist() == [[True, True, True, False, False, True, False, False]]
+
+
+def test_masked_future_values_cannot_change_static_decode() -> None:
+    _, static = _blocks()
+    torch.manual_seed(29)
+    x = torch.randn(1, 1, 4)
+    prefix_k = torch.randn(1, 3, 4)
+    prefix_v = torch.randn(1, 3, 4)
+    pos_idx = torch.full((1, 1, 4), 3, dtype=torch.long)
+
+    def decode(future_scale: float) -> torch.Tensor:
+        k_cache = torch.randn(1, 8, 4) * future_scale
+        v_cache = torch.randn(1, 8, 4) * future_scale
+        k_cache[:, :3] = prefix_k
+        v_cache[:, :3] = prefix_v
+        valid = torch.zeros(1, 8, dtype=torch.bool)
+        valid[:, :3] = True
+        output, _, _ = static.decode_next_token_with_static_cache(
+            x.clone(), k_cache, v_cache, pos_idx, valid
+        )
+        return output
+
+    torch.testing.assert_close(decode(1.0), decode(1000.0), rtol=1e-5, atol=1e-5)
+
+
+def test_non_graph_static_prefix_matches_dynamic_without_mask_kernel() -> None:
+    dynamic, static = _blocks()
+    torch.manual_seed(31)
+    x = torch.randn(1, 1, 4)
+    prefix_k = torch.randn(1, 3, 4)
+    prefix_v = torch.randn(1, 3, 4)
+    expected, _, _ = dynamic.decode_next_token(
+        x.clone(), prefix_k.clone(), prefix_v.clone()
+    )
+    k_cache = torch.randn(1, 8, 4) * 100
+    v_cache = torch.randn(1, 8, 4) * 100
+    k_cache[:, :3] = prefix_k
+    v_cache[:, :3] = prefix_v
+    pos_idx = torch.full((1, 1, 4), 3, dtype=torch.long)
+    valid = torch.zeros(1, 8, dtype=torch.bool)
+    valid[:, :3] = True
+    transformer = T2STransformerWithStaticCache(1, [static])
+
+    actual, _, _ = transformer.decode_next_token_with_static_cache(
+        x.clone(), [k_cache], [v_cache], pos_idx, valid, 4
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)

--- a/tests/test_tts_semantic_stability.py
+++ b/tests/test_tts_semantic_stability.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from tts.semantic_stability import assess_semantic_candidate
+
+
+def test_accepts_long_diverse_candidate_without_using_length_as_a_hard_cap() -> None:
+    tokens = [index % 37 for index in range(180)]
+
+    result = assess_semantic_candidate(
+        tokens,
+        target_phone_count=20,
+        max_generation_tokens=400,
+    )
+
+    assert result.soft_token_budget == 96
+    assert result.accepted is True
+    assert result.reasons == ()
+
+
+def test_rejects_checkpoint_independent_equal_token_collapse() -> None:
+    tokens = list(range(24)) + [937] * 48
+
+    result = assess_semantic_candidate(
+        tokens,
+        target_phone_count=48,
+        max_generation_tokens=400,
+    )
+
+    assert result.accepted is False
+    assert "equal_token_collapse" in result.reasons
+    assert result.longest_equal_run == 48
+
+
+def test_rejects_short_periodic_loop_without_token_id_exceptions() -> None:
+    tokens = [11, 29, 47, 53] * 18
+
+    result = assess_semantic_candidate(
+        tokens,
+        target_phone_count=6,
+        max_generation_tokens=400,
+    )
+
+    assert result.accepted is False
+    assert "periodic_token_collapse" in result.reasons
+    assert result.periodic_run_period == 4
+
+
+def test_rejects_budget_overrun_only_when_repetition_is_also_present() -> None:
+    tokens = list(range(80)) + [3, 7] * 20
+
+    result = assess_semantic_candidate(
+        tokens,
+        target_phone_count=6,
+        max_generation_tokens=400,
+    )
+
+    assert result.token_count > result.soft_token_budget
+    assert result.accepted is False
+    assert result.reasons == ("length_with_repetition",)
+
+
+def test_budget_overrun_with_moderate_equal_run_catches_long_filler() -> None:
+    tokens = list(range(84)) + [311] * 20
+
+    result = assess_semantic_candidate(
+        tokens,
+        target_phone_count=6,
+        max_generation_tokens=400,
+    )
+
+    assert result.soft_token_budget == 96
+    assert result.accepted is False
+    assert result.reasons == ("length_with_repetition",)
+
+
+def test_rejects_empty_candidate() -> None:
+    result = assess_semantic_candidate(
+        [],
+        target_phone_count=8,
+        max_generation_tokens=400,
+    )
+
+    assert result.accepted is False
+    assert result.reasons == ("empty_candidate",)

--- a/tools/probes/probe_gsv_stability.py
+++ b/tools/probes/probe_gsv_stability.py
@@ -1,0 +1,803 @@
+"""Paired-seed stability probe for Amadeus's GPT-SoVITS T2S decoder.
+
+The probe intentionally stops after semantic-token generation.  That makes it
+cheap enough to sweep intermittent failures while still observing the layer
+that owns EOS, repetition, and the static/CUDA-Graph KV-cache variants.
+
+Example:
+
+    .venv\\Scripts\\python.exe -X utf8 tools\\probes\\probe_gsv_stability.py \
+        --cuda-visible-devices 0 --device cuda:0 --trials 20
+
+Results are written below ``output/diagnostics`` by default.  The probe does
+not play audio or mutate runtime/model state outside its own process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import io
+import json
+import math
+import os
+import random
+import statistics
+import sys
+import time
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class ProbeMode:
+    name: str
+    enable_cuda_graph: bool
+    enable_static_kv: bool
+
+
+MODES = {
+    "graph_static": ProbeMode("graph_static", True, True),
+    "static": ProbeMode("static", False, True),
+    "dynamic": ProbeMode("dynamic", False, False),
+}
+
+
+@dataclass(frozen=True)
+class ProbeCase:
+    name: str
+    text: str
+    family: str
+
+
+CASES = (
+    ProbeCase("aa_weak", "ああ、", "standalone_weak"),
+    ProbeCase("eeto_weak", "ええと、", "standalone_weak"),
+    ProbeCase("uun_weak", "うーん、", "standalone_weak"),
+    ProbeCase("uun_ellipsis", "うーん……", "standalone_ellipsis"),
+    ProbeCase("aa_strong", "ああ。", "standalone_strong"),
+    ProbeCase("eeto_strong", "ええと。", "standalone_strong"),
+    ProbeCase("uun_strong", "うーん。", "standalone_strong"),
+    ProbeCase("aa_continuation", "ああ、それなら簡単よ。", "continuation"),
+    ProbeCase("eeto_continuation", "ええと、まず条件を整理しましょう。", "continuation"),
+    ProbeCase(
+        "uun_continuation",
+        "うーん……正直、まだ完全には分からないわ。",
+        "continuation",
+    ),
+    ProbeCase("control_plain", "それなら簡単よ。", "control"),
+)
+
+QUICK_CASE_NAMES = {
+    "aa_weak",
+    "uun_ellipsis",
+    "uun_continuation",
+    "control_plain",
+}
+
+
+@dataclass
+class SemanticContext:
+    case: ProbeCase
+    synthesis_text: str
+    normalized_text: str
+    target_phone_count: int
+    all_phoneme_ids: Any
+    all_phoneme_len: Any
+    prompt_semantic: Any
+    bert: Any
+
+
+def _parse_csv(value: str) -> list[str]:
+    return [part.strip() for part in str(value or "").split(",") if part.strip()]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run paired-seed GPT-SoVITS semantic stability comparisons."
+    )
+    parser.add_argument("--trials", type=int, default=20, help="Seeds per case and mode.")
+    parser.add_argument("--seed-start", type=int, default=1000)
+    parser.add_argument(
+        "--modes",
+        default="graph_static,static,dynamic",
+        help="Comma-separated subset of graph_static, static, dynamic.",
+    )
+    parser.add_argument(
+        "--cases",
+        default="all",
+        help="all, quick, or comma-separated case names.",
+    )
+    parser.add_argument(
+        "--max-sec",
+        type=float,
+        default=12.0,
+        help="Diagnostic hard stop. A short-case hit is already an anomaly.",
+    )
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--temperature", type=float, default=0.6)
+    parser.add_argument("--repetition-penalty", type=float, default=1.35)
+    parser.add_argument(
+        "--semantic-retries",
+        type=int,
+        default=0,
+        help="Retry rejected semantic candidates this many times (0 preserves raw decoder A/B).",
+    )
+    parser.add_argument("--retry-repetition-penalty", type=float, default=1.5)
+    parser.add_argument(
+        "--cuda-visible-devices",
+        default=None,
+        help="Set before importing torch; useful for isolating the probe on a spare GPU.",
+    )
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--output", default="")
+    parser.add_argument("--verbose-model", action="store_true")
+    parser.add_argument("--skip-graph-warmup", action="store_true")
+    parser.add_argument(
+        "--load-vocoder",
+        action="store_true",
+        help="Load the production BigVGAN stack even though trials stop after T2S.",
+    )
+    return parser.parse_args()
+
+
+def _configure_process(args: argparse.Namespace) -> None:
+    if args.cuda_visible_devices is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.cuda_visible_devices)
+    os.environ["TTS_DEVICE"] = str(args.device)
+    os.environ["ENABLE_CUDA_GRAPH"] = "1" if "graph_static" in _parse_csv(args.modes) else "0"
+    os.environ["ENABLE_CUDA_GRAPH_PRECAPTURE"] = "0"
+    os.environ["TTS_RUNTIME_WARMUP"] = "0"
+    os.environ["TTS_SESSION_WARMUP"] = "0"
+    os.environ["PYTHONIOENCODING"] = "utf-8"
+    os.environ["PYTHONUTF8"] = "1"
+
+
+def _select_modes(value: str) -> list[ProbeMode]:
+    names = _parse_csv(value)
+    unknown = [name for name in names if name not in MODES]
+    if unknown:
+        raise ValueError(f"unknown modes: {', '.join(unknown)}")
+    if not names:
+        raise ValueError("at least one mode is required")
+    return [MODES[name] for name in names]
+
+
+def _select_cases(value: str) -> list[ProbeCase]:
+    clean = str(value or "").strip().lower()
+    if clean == "all":
+        return list(CASES)
+    if clean == "quick":
+        return [case for case in CASES if case.name in QUICK_CASE_NAMES]
+    names = set(_parse_csv(value))
+    known = {case.name for case in CASES}
+    unknown = sorted(names - known)
+    if unknown:
+        raise ValueError(f"unknown cases: {', '.join(unknown)}")
+    selected = [case for case in CASES if case.name in names]
+    if not selected:
+        raise ValueError("at least one case is required")
+    return selected
+
+
+def _set_seed(seed: int, torch_module: Any) -> None:
+    random.seed(seed)
+    try:
+        import numpy as np
+
+        np.random.seed(seed)
+    except Exception:
+        pass
+    torch_module.manual_seed(seed)
+    if torch_module.cuda.is_available():
+        torch_module.cuda.manual_seed_all(seed)
+
+
+def _longest_equal_run(tokens: list[int]) -> int:
+    return _longest_equal_run_with_token(tokens)[0]
+
+
+def _longest_equal_run_with_token(tokens: list[int]) -> tuple[int, int | None]:
+    best = 0
+    best_token: int | None = None
+    current = 0
+    previous: int | None = None
+    for token in tokens:
+        if token == previous:
+            current += 1
+        else:
+            previous = token
+            current = 1
+        if current > best:
+            best = current
+            best_token = token
+    return best, best_token
+
+
+def _periodic_run(tokens: list[int], max_period: int = 8) -> tuple[int, int]:
+    """Return (longest run, period) for short repeating token patterns."""
+
+    best_run = 0
+    best_period = 0
+    for period in range(1, max_period + 1):
+        current = 0
+        for index in range(period, len(tokens)):
+            if tokens[index] == tokens[index - period]:
+                current = current + 1 if current else period + 1
+            else:
+                current = 0
+            if current > best_run:
+                best_run = current
+                best_period = period
+    return best_run, best_period
+
+
+def _token_metrics(tokens: list[int]) -> dict[str, float | int]:
+    if not tokens:
+        return {
+            "token_count": 0,
+            "unique_ratio": 0.0,
+            "adjacent_repeat_ratio": 0.0,
+            "top_token_ratio": 0.0,
+            "longest_equal_run": 0,
+            "longest_equal_run_token": -1,
+            "longest_periodic_run": 0,
+            "periodic_run_period": 0,
+        }
+    counts = Counter(tokens)
+    adjacent = sum(left == right for left, right in zip(tokens, tokens[1:]))
+    equal_run, equal_run_token = _longest_equal_run_with_token(tokens)
+    periodic_run, periodic_period = _periodic_run(tokens)
+    return {
+        "token_count": len(tokens),
+        "unique_ratio": len(counts) / len(tokens),
+        "adjacent_repeat_ratio": adjacent / max(1, len(tokens) - 1),
+        "top_token_ratio": max(counts.values()) / len(tokens),
+        "longest_equal_run": equal_run,
+        "longest_equal_run_token": -1 if equal_run_token is None else equal_run_token,
+        "longest_periodic_run": periodic_run,
+        "periodic_run_period": periodic_period,
+    }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _quantile(values: list[float], fraction: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * fraction
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return float(ordered[lower])
+    weight = position - lower
+    return float(ordered[lower] * (1 - weight) + ordered[upper] * weight)
+
+
+def _median_absolute_deviation(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    median = statistics.median(values)
+    return float(statistics.median(abs(value - median) for value in values))
+
+
+def _mark_anomalies(rows: list[dict[str, Any]]) -> None:
+    by_case: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        if row.get("error"):
+            continue
+        by_case.setdefault(str(row["case"]), []).append(row)
+
+    for case_rows in by_case.values():
+        lengths = [float(row["token_count"]) for row in case_rows]
+        median = statistics.median(lengths) if lengths else 0.0
+        mad = _median_absolute_deviation(lengths)
+        relative_limit = max(64.0, median * 2.0, median + 6.0 * max(1.0, mad))
+        for row in case_rows:
+            reasons: list[str] = []
+            if row["termination"] != "eos":
+                reasons.append(str(row["termination"]))
+            if float(row["token_count"]) > relative_limit:
+                reasons.append("length_outlier")
+            run_token = int(row.get("longest_equal_run_token", -1))
+            run_limit = 75 if run_token == 486 else 32
+            if int(row["longest_equal_run"]) >= run_limit:
+                reasons.append("equal_token_run")
+            if int(row["longest_periodic_run"]) >= 48:
+                reasons.append("periodic_token_run")
+            if int(row["token_count"]) >= 32 and float(row["top_token_ratio"]) >= 0.55:
+                reasons.append("token_concentration")
+            row["case_token_median"] = float(median)
+            row["case_token_mad"] = float(mad)
+            row["case_length_limit"] = float(relative_limit)
+            row["anomaly_reasons"] = reasons
+            row["anomalous"] = bool(reasons)
+
+
+def _mark_paired_differences(rows: list[dict[str, Any]]) -> None:
+    paired: dict[tuple[str, int], dict[str, dict[str, Any]]] = {}
+    for row in rows:
+        if row.get("error"):
+            continue
+        key = (str(row["case"]), int(row["seed"]))
+        paired.setdefault(key, {})[str(row["mode"])] = row
+
+    for modes in paired.values():
+        dynamic = modes.get("dynamic")
+        static = modes.get("static")
+        for row in modes.values():
+            if dynamic is None or row is dynamic:
+                row["paired_dynamic_match"] = None
+                row["paired_dynamic_token_delta"] = None
+            else:
+                row["paired_dynamic_match"] = row["token_sha256"] == dynamic["token_sha256"]
+                row["paired_dynamic_token_delta"] = int(row["token_count"]) - int(dynamic["token_count"])
+            if static is None or row is static:
+                row["paired_static_match"] = None
+                row["paired_static_token_delta"] = None
+            else:
+                row["paired_static_match"] = row["token_sha256"] == static["token_sha256"]
+                row["paired_static_token_delta"] = int(row["token_count"]) - int(static["token_count"])
+
+
+def _summarize(rows: list[dict[str, Any]], trials: int) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for row in rows:
+        groups.setdefault((str(row["case"]), str(row["mode"])), []).append(row)
+
+    summary: list[dict[str, Any]] = []
+    for (case_name, mode_name), group in sorted(groups.items()):
+        valid = [row for row in group if not row.get("error")]
+        lengths = [float(row["token_count"]) for row in valid]
+        runtimes = [float(row["elapsed_sec"]) for row in valid]
+        anomalies = [row for row in valid if row.get("anomalous")]
+        eos_count = sum(row.get("termination") == "eos" for row in valid)
+        paired_rows = [row for row in valid if row.get("paired_dynamic_match") is not None]
+        paired_deltas = [abs(float(row["paired_dynamic_token_delta"])) for row in paired_rows]
+        static_paired_rows = [row for row in valid if row.get("paired_static_match") is not None]
+        summary.append(
+            {
+                "case": case_name,
+                "mode": mode_name,
+                "requested_trials": trials,
+                "completed": len(valid),
+                "errors": len(group) - len(valid),
+                "eos_rate": eos_count / len(valid) if valid else None,
+                "anomaly_count": len(anomalies),
+                "anomaly_rate": len(anomalies) / len(valid) if valid else None,
+                "token_median": statistics.median(lengths) if lengths else None,
+                "token_p95": _quantile(lengths, 0.95),
+                "token_max": max(lengths) if lengths else None,
+                "elapsed_median_sec": statistics.median(runtimes) if runtimes else None,
+                "elapsed_p95_sec": _quantile(runtimes, 0.95),
+                "paired_dynamic_match_rate": (
+                    sum(bool(row["paired_dynamic_match"]) for row in paired_rows) / len(paired_rows)
+                    if paired_rows
+                    else None
+                ),
+                "paired_dynamic_abs_token_delta_median": (
+                    statistics.median(paired_deltas) if paired_deltas else None
+                ),
+                "paired_static_match_rate": (
+                    sum(bool(row["paired_static_match"]) for row in static_paired_rows)
+                    / len(static_paired_rows)
+                    if static_paired_rows
+                    else None
+                ),
+            }
+        )
+    return summary
+
+
+def _write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# GPT-SoVITS stability probe",
+        "",
+        f"Generated: `{payload['metadata']['generated_at']}`",
+        "",
+        "| Case | Mode | Done | EOS | Anomalies | Token median / p95 / max | Time median / p95 | Match dynamic |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for item in payload["summary"]:
+        eos = "-" if item["eos_rate"] is None else f"{item['eos_rate']:.1%}"
+        anomaly = "-" if item["anomaly_rate"] is None else f"{item['anomaly_count']} ({item['anomaly_rate']:.1%})"
+        token_values = " / ".join(
+            "-" if item[key] is None else f"{item[key]:.0f}"
+            for key in ("token_median", "token_p95", "token_max")
+        )
+        time_values = " / ".join(
+            "-" if item[key] is None else f"{item[key]:.3f}s"
+            for key in ("elapsed_median_sec", "elapsed_p95_sec")
+        )
+        match_dynamic = (
+            "-"
+            if item["paired_dynamic_match_rate"] is None
+            else f"{item['paired_dynamic_match_rate']:.1%}"
+        )
+        lines.append(
+            f"| {item['case']} | {item['mode']} | {item['completed']} | {eos} | "
+            f"{anomaly} | {token_values} | {time_values} | {match_dynamic} |"
+        )
+    lines.extend(["", "## Anomalous trials", ""])
+    anomalous = [row for row in payload["rows"] if row.get("anomalous") or row.get("error")]
+    if not anomalous:
+        lines.append("None detected by the probe thresholds.")
+    else:
+        lines.append("| Case | Mode | Seed | Tokens | Stop | Reasons / error |")
+        lines.append("|---|---:|---:|---:|---:|---|")
+        for row in anomalous:
+            detail = row.get("error") or ", ".join(row.get("anomaly_reasons") or [])
+            lines.append(
+                f"| {row['case']} | {row['mode']} | {row['seed']} | "
+                f"{row.get('token_count', '-')} | {row.get('termination', '-')} | {detail} |"
+            )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _model_output_context(verbose: bool):
+    return contextlib.nullcontext() if verbose else contextlib.redirect_stdout(io.StringIO())
+
+
+def _build_contexts(inferencer: Any, cases: Iterable[ProbeCase], torch_module: Any) -> list[SemanticContext]:
+    from config import settings
+
+    text_language = settings.TTS_OUTPUT_LANGUAGE
+    prompt_language = settings.TTS_OUTPUT_LANGUAGE
+    reference_audio = (
+        settings.TTS_REF_AUDIO_EN
+        if str(settings.TTS_OUTPUT_LANGUAGE).strip() == "英文"
+        else settings.TTS_REF_AUDIO_JA
+    )
+    prompt_text = (
+        settings.TTS_REF_TEXT_EN
+        if str(settings.TTS_OUTPUT_LANGUAGE).strip() == "英文"
+        else settings.TTS_REF_TEXT_JA
+    )
+    reference_path = Path(reference_audio)
+    if not reference_path.is_absolute():
+        reference_path = ROOT / reference_path
+    if not reference_path.exists():
+        raise FileNotFoundError(f"reference audio not found: {reference_path}")
+
+    prompt_text = str(prompt_text or "").strip()
+    if prompt_text and prompt_text[-1] not in inferencer.splits:
+        prompt_text += "." if prompt_language == "英文" else "。"
+
+    prompt_code = inferencer.dict_language.get(prompt_language)
+    text_code = inferencer.dict_language.get(text_language)
+    if prompt_code is None or text_code is None:
+        raise KeyError(
+            f"language mapping unavailable: prompt={prompt_language!r} text={text_language!r}"
+        )
+
+    session = inferencer._build_session_cache(str(reference_path), prompt_text, prompt_code)
+    prompt_semantic = session.get("prompt")
+    if prompt_semantic is None:
+        raise RuntimeError("reference session did not produce prompt semantic tokens")
+    if "phones1" in session and "bert1" in session:
+        phones1, bert1 = session["phones1"], session["bert1"]
+    else:
+        phones1, bert1, _ = inferencer.get_phones_and_bert(prompt_text, prompt_code)
+
+    contexts: list[SemanticContext] = []
+    for case in cases:
+        synthesis_text = case.text.strip()
+        if synthesis_text and synthesis_text[-1] not in inferencer.splits:
+            synthesis_text += "." if text_language == "英文" else "。"
+        phones2, bert2, normalized = inferencer.get_phones_and_bert(synthesis_text, text_code)
+        all_ids = torch_module.LongTensor(phones1 + phones2).to(inferencer.device).unsqueeze(0)
+        all_len = torch_module.tensor([all_ids.shape[-1]]).to(inferencer.device)
+        bert = torch_module.cat([bert1, bert2], 1).to(inferencer.device).unsqueeze(0)
+        contexts.append(
+            SemanticContext(
+                case=case,
+                synthesis_text=synthesis_text,
+                normalized_text=str(normalized),
+                target_phone_count=len(phones2),
+                all_phoneme_ids=all_ids,
+                all_phoneme_len=all_len,
+                prompt_semantic=prompt_semantic,
+                bert=bert,
+            )
+        )
+    return contexts
+
+
+def _run_trial(
+    *,
+    inferencer: Any,
+    context: SemanticContext,
+    mode: ProbeMode,
+    seed: int,
+    early_stop_num: int,
+    args: argparse.Namespace,
+    torch_module: Any,
+    t2s_module: Any,
+) -> dict[str, Any]:
+    tracker = {"eos": False, "checks": 0}
+    original_eos = t2s_module._should_stop_on_eos
+
+    def tracked_eos(logits: Any, samples: Any, eos: int) -> bool:
+        result = original_eos(logits, samples, eos)
+        tracker["checks"] += 1
+        tracker["eos"] = bool(tracker["eos"] or result)
+        return result
+
+    t2s_module._should_stop_on_eos = tracked_eos
+    _set_seed(seed, torch_module)
+    started = time.perf_counter()
+    try:
+        from tts.semantic_stability import assess_semantic_candidate
+
+        rejected_attempts: list[dict[str, Any]] = []
+        penalties = [args.repetition_penalty] + [
+            args.retry_repetition_penalty
+        ] * args.semantic_retries
+        final_values: dict[str, Any] | None = None
+        if torch_module.cuda.is_available() and str(inferencer.device).startswith("cuda"):
+            torch_module.cuda.synchronize(inferencer.device)
+
+        for attempt, penalty in enumerate(penalties, start=1):
+            tracker = {"eos": False, "checks": 0}
+            with torch_module.inference_mode(), _model_output_context(args.verbose_model):
+                prediction, idx = inferencer.t2s_model.model.infer_panel(
+                    context.all_phoneme_ids,
+                    context.all_phoneme_len,
+                    context.prompt_semantic,
+                    context.bert,
+                    top_k=args.top_k,
+                    top_p=args.top_p,
+                    temperature=args.temperature,
+                    repetition_penalty=penalty,
+                    early_stop_num=early_stop_num,
+                    enable_cuda_graph=mode.enable_cuda_graph,
+                    enable_static_kv=mode.enable_static_kv,
+                )
+            generated_count = max(0, int(idx))
+            if generated_count:
+                tokens = prediction[0, -generated_count:].detach().cpu().long().tolist()
+            else:
+                tokens = []
+            metrics = _token_metrics(tokens)
+            token_bytes = ",".join(str(token) for token in tokens).encode("ascii")
+            if tracker["eos"]:
+                termination = "eos"
+            elif generated_count >= early_stop_num:
+                termination = "early_stop"
+            elif generated_count >= 1499:
+                termination = "loop_limit"
+            else:
+                termination = "unknown"
+            assessment = assess_semantic_candidate(
+                tokens,
+                target_phone_count=context.target_phone_count,
+                max_generation_tokens=early_stop_num,
+            )
+            final_values = {
+                "termination": termination,
+                "eos_checks": int(tracker["checks"]),
+                **metrics,
+                "token_sha256": hashlib.sha256(token_bytes).hexdigest(),
+                "token_preview": tokens[:16],
+                "token_tail": tokens[-16:],
+                "guard_reasons": list(assessment.reasons),
+                "guard_exhausted": not assessment.accepted,
+                "semantic_attempts": attempt,
+            }
+            if assessment.accepted or attempt == len(penalties):
+                break
+            rejected_attempts.append(
+                {
+                    "attempt": attempt,
+                    "repetition_penalty": penalty,
+                    "token_count": metrics["token_count"],
+                    "termination": termination,
+                    "reasons": list(assessment.reasons),
+                }
+            )
+
+        if torch_module.cuda.is_available() and str(inferencer.device).startswith("cuda"):
+            torch_module.cuda.synchronize(inferencer.device)
+        elapsed = time.perf_counter() - started
+        if final_values is None:
+            raise RuntimeError("semantic probe produced no candidate")
+        return {
+            "case": context.case.name,
+            "family": context.case.family,
+            "text": context.case.text,
+            "synthesis_text": context.synthesis_text,
+            "normalized_text": context.normalized_text,
+            "target_phone_count": context.target_phone_count,
+            "mode": mode.name,
+            "seed": seed,
+            "elapsed_sec": elapsed,
+            "rejected_attempts": rejected_attempts,
+            **final_values,
+        }
+    except Exception as exc:
+        if torch_module.cuda.is_available() and str(inferencer.device).startswith("cuda"):
+            try:
+                torch_module.cuda.synchronize(inferencer.device)
+            except Exception:
+                pass
+        return {
+            "case": context.case.name,
+            "family": context.case.family,
+            "text": context.case.text,
+            "mode": mode.name,
+            "seed": seed,
+            "elapsed_sec": time.perf_counter() - started,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    finally:
+        t2s_module._should_stop_on_eos = original_eos
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.trials < 1:
+        raise ValueError("--trials must be positive")
+    if args.max_sec <= 0:
+        raise ValueError("--max-sec must be positive")
+    if args.semantic_retries < 0:
+        raise ValueError("--semantic-retries cannot be negative")
+    modes = _select_modes(args.modes)
+    cases = _select_cases(args.cases)
+    _configure_process(args)
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+    import torch
+
+    from config import settings
+    from local_tts_infer import TTSInferencer
+
+    class SemanticOnlyInferencer(TTSInferencer):
+        def _load_bigvgan_model(self) -> None:
+            self.bigvgan_model = None
+
+    print(
+        f"[probe] device={args.device} visible={os.environ.get('CUDA_VISIBLE_DEVICES', 'all')} "
+        f"modes={[mode.name for mode in modes]} cases={len(cases)} trials={args.trials}"
+    )
+    load_started = time.perf_counter()
+    inferencer_class = TTSInferencer if args.load_vocoder else SemanticOnlyInferencer
+    with _model_output_context(args.verbose_model):
+        inferencer = inferencer_class(
+            device=args.device,
+            gpt_path=settings.TTS_GPT_MODEL_PATH or None,
+            sovits_path=settings.TTS_SOVITS_MODEL_PATH or None,
+        )
+        contexts = _build_contexts(inferencer, cases, torch)
+    import importlib
+
+    # The vendored package supports two import roots.  Resolve the module from
+    # the live decoder class so the EOS hook and tqdm replacement affect the
+    # exact globals used by inference rather than a duplicate module object.
+    t2s_module = importlib.import_module(inferencer.t2s_model.model.__class__.__module__)
+    t2s_module.tqdm = lambda values: values
+    print(f"[probe] models and contexts ready in {time.perf_counter() - load_started:.1f}s")
+
+    early_stop_num = int(inferencer.hz * args.max_sec)
+    graph_mode = next((mode for mode in modes if mode.enable_cuda_graph), None)
+    if graph_mode is not None and not args.skip_graph_warmup:
+        print("[probe] warming CUDA Graph keys (discarded trials)")
+        for index, context in enumerate(contexts):
+            row = _run_trial(
+                inferencer=inferencer,
+                context=context,
+                mode=graph_mode,
+                seed=args.seed_start - 10000 - index,
+                early_stop_num=early_stop_num,
+                args=args,
+                torch_module=torch,
+                t2s_module=t2s_module,
+            )
+            if row.get("error"):
+                print(f"[probe] graph warmup failed for {context.case.name}: {row['error']}")
+
+    rows: list[dict[str, Any]] = []
+    total = len(contexts) * len(modes) * args.trials
+    completed = 0
+    run_started = time.perf_counter()
+    for offset in range(args.trials):
+        seed = args.seed_start + offset
+        for context in contexts:
+            for mode in modes:
+                row = _run_trial(
+                    inferencer=inferencer,
+                    context=context,
+                    mode=mode,
+                    seed=seed,
+                    early_stop_num=early_stop_num,
+                    args=args,
+                    torch_module=torch,
+                    t2s_module=t2s_module,
+                )
+                rows.append(row)
+                completed += 1
+                if completed == total or completed % max(1, min(25, total // 10)) == 0:
+                    elapsed = time.perf_counter() - run_started
+                    print(f"[probe] {completed}/{total} trials ({elapsed:.1f}s)")
+
+    _mark_anomalies(rows)
+    _mark_paired_differences(rows)
+    summary = _summarize(rows, args.trials)
+    now = datetime.now().astimezone()
+    output_path = Path(args.output) if args.output else (
+        ROOT / "output" / "diagnostics" / f"gsv_stability_{now:%Y%m%d_%H%M%S}.json"
+    )
+    if not output_path.is_absolute():
+        output_path = ROOT / output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    gpt_path = Path(settings.TTS_GPT_MODEL_PATH)
+    sovits_path = Path(settings.TTS_SOVITS_MODEL_PATH)
+    payload = {
+        "metadata": {
+            "generated_at": now.isoformat(),
+            "device": str(args.device),
+            "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+            "gpu_name": (
+                torch.cuda.get_device_name(torch.device(args.device))
+                if torch.cuda.is_available() and str(args.device).startswith("cuda")
+                else None
+            ),
+            "torch_version": torch.__version__,
+            "trials_per_case_mode": args.trials,
+            "seed_start": args.seed_start,
+            "max_sec": args.max_sec,
+            "early_stop_num": early_stop_num,
+            "semantic_retries": args.semantic_retries,
+            "retry_repetition_penalty": args.retry_repetition_penalty,
+            "top_k": args.top_k,
+            "top_p": args.top_p,
+            "temperature": args.temperature,
+            "repetition_penalty": args.repetition_penalty,
+            "load_vocoder": bool(args.load_vocoder),
+            "modes": [asdict(mode) for mode in modes],
+            "cases": [asdict(case) for case in cases],
+            "model_max_sec": float(inferencer.max_sec),
+            "gpt_model": str(gpt_path),
+            "gpt_sha256": _sha256(gpt_path),
+            "sovits_model": str(sovits_path),
+            "sovits_sha256": _sha256(sovits_path),
+            "elapsed_sec": time.perf_counter() - run_started,
+        },
+        "summary": summary,
+        "rows": rows,
+    }
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    markdown_path = output_path.with_suffix(".md")
+    _write_markdown(markdown_path, payload)
+
+    total_anomalies = sum(bool(row.get("anomalous")) for row in rows)
+    total_errors = sum(bool(row.get("error")) for row in rows)
+    print(
+        f"[probe] done: rows={len(rows)} anomalies={total_anomalies} errors={total_errors}\n"
+        f"[probe] json={output_path}\n[probe] report={markdown_path}"
+    )
+    return 0 if total_errors == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/probes/render_gsv_stability_samples.py
+++ b/tools/probes/render_gsv_stability_samples.py
@@ -1,0 +1,234 @@
+"""Render a small set of paired audio samples from a GSV stability sweep."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.probes.probe_gsv_stability import CASES, MODES, _set_seed, _token_metrics
+
+
+DEFAULT_SELECTIONS = (
+    "eeto_weak:dynamic:2013",
+    "eeto_strong:dynamic:2013",
+    "uun_continuation:static:2001",
+    "uun_continuation:dynamic:2001",
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render selected paired GSV probe samples.")
+    parser.add_argument("--selection", action="append", default=[])
+    parser.add_argument("--cuda-visible-devices", default=None)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--max-sec", type=float, default=8.0)
+    parser.add_argument("--output-dir", default="output/diagnostics/gsv_stability_audio")
+    parser.add_argument("--verbose-model", action="store_true")
+    return parser.parse_args()
+
+
+def _configure(args: argparse.Namespace, selections: list[tuple[str, str, int]]) -> None:
+    if args.cuda_visible_devices is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.cuda_visible_devices)
+    os.environ["TTS_DEVICE"] = str(args.device)
+    os.environ["ENABLE_CUDA_GRAPH"] = (
+        "1" if any(MODES[mode].enable_cuda_graph for _, mode, _ in selections) else "0"
+    )
+    os.environ["ENABLE_CUDA_GRAPH_PRECAPTURE"] = "0"
+    os.environ["TTS_RUNTIME_WARMUP"] = "0"
+    os.environ["TTS_SESSION_WARMUP"] = "0"
+    os.environ["PYTHONIOENCODING"] = "utf-8"
+    os.environ["PYTHONUTF8"] = "1"
+
+
+def _parse_selections(values: list[str]) -> list[tuple[str, str, int]]:
+    parsed: list[tuple[str, str, int]] = []
+    known_cases = {case.name for case in CASES}
+    for value in values or list(DEFAULT_SELECTIONS):
+        try:
+            case, mode, seed_text = value.rsplit(":", 2)
+            seed = int(seed_text)
+        except ValueError as exc:
+            raise ValueError(f"invalid selection {value!r}; expected case:mode:seed") from exc
+        if case not in known_cases:
+            raise ValueError(f"unknown case in selection: {case}")
+        if mode not in MODES:
+            raise ValueError(f"unknown mode in selection: {mode}")
+        parsed.append((case, mode, seed))
+    return parsed
+
+
+def _audio_metrics(audio: Any, sample_rate: int) -> dict[str, float | int]:
+    import numpy as np
+
+    values = np.asarray(audio, dtype=np.float32).reshape(-1)
+    return {
+        "sample_rate": int(sample_rate),
+        "samples": int(values.size),
+        "duration_sec": float(values.size / max(1, sample_rate)),
+        "peak": float(np.max(np.abs(values))) if values.size else 0.0,
+        "rms": float(np.sqrt(np.mean(values * values))) if values.size else 0.0,
+        "near_silence_ratio": float(np.mean(np.abs(values) < 1e-3)) if values.size else 1.0,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    selections = _parse_selections(args.selection)
+    _configure(args, selections)
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+    import numpy as np
+    import soundfile as sf
+    import torch
+
+    from config import settings
+    from local_tts_infer import TTSInferencer
+
+    cases = {case.name: case for case in CASES}
+    reference_audio = (
+        settings.TTS_REF_AUDIO_EN
+        if str(settings.TTS_OUTPUT_LANGUAGE).strip() == "英文"
+        else settings.TTS_REF_AUDIO_JA
+    )
+    reference_text = (
+        settings.TTS_REF_TEXT_EN
+        if str(settings.TTS_OUTPUT_LANGUAGE).strip() == "英文"
+        else settings.TTS_REF_TEXT_JA
+    )
+    reference_path = Path(reference_audio)
+    if not reference_path.is_absolute():
+        reference_path = ROOT / reference_path
+
+    output_dir = Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = ROOT / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[render] loading full v3 stack on {args.device}")
+    inferencer = TTSInferencer(
+        device=args.device,
+        gpt_path=settings.TTS_GPT_MODEL_PATH or None,
+        sovits_path=settings.TTS_SOVITS_MODEL_PATH or None,
+    )
+    decoder = inferencer.t2s_model.model
+    decoder_class = type(decoder)
+    original_infer_panel = decoder_class.infer_panel
+    current_semantic: dict[str, Any] = {}
+
+    def tracked_infer_panel(self: Any, *call_args: Any, **call_kwargs: Any):
+        prediction, idx = original_infer_panel(self, *call_args, **call_kwargs)
+        count = max(0, int(idx))
+        tokens = (
+            prediction[0, -count:].detach().cpu().long().tolist()
+            if count
+            else []
+        )
+        metrics = _token_metrics(tokens)
+        attempts = current_semantic.setdefault("semantic_attempts", [])
+        attempts.append(
+            {
+                **metrics,
+                "repetition_penalty": float(call_kwargs.get("repetition_penalty", 1.35)),
+                "token_preview": tokens[:16],
+                "token_tail": tokens[-16:],
+            }
+        )
+        current_semantic.update(metrics)
+        current_semantic["semantic_attempt_count"] = len(attempts)
+        current_semantic["token_preview"] = tokens[:16]
+        current_semantic["token_tail"] = tokens[-16:]
+        return prediction, idx
+
+    decoder_class.infer_panel = tracked_infer_panel
+    manifest: list[dict[str, Any]] = []
+    try:
+        for case_name, mode_name, seed in selections:
+            case = cases[case_name]
+            mode = MODES[mode_name]
+            current_semantic.clear()
+            _set_seed(seed, torch)
+            started = time.perf_counter()
+            model_output = contextlib.nullcontext() if args.verbose_model else contextlib.redirect_stdout(io.StringIO())
+            with model_output:
+                sample_rate, audio = inferencer.infer(
+                    text=case.text,
+                    ref_audio_path=str(reference_path),
+                    prompt_text=reference_text,
+                    text_language=settings.TTS_OUTPUT_LANGUAGE,
+                    prompt_language=settings.TTS_OUTPUT_LANGUAGE,
+                    how_to_cut="不切",
+                    top_k=5,
+                    top_p=1.0,
+                    temperature=0.6,
+                    speed=1.0,
+                    sample_steps=16,
+                    pause_second=0.05,
+                    if_sr=False,
+                    enable_cuda_graph=mode.enable_cuda_graph,
+                    enable_static_kv=mode.enable_static_kv,
+                    max_sec_override=args.max_sec,
+                )
+            elapsed = time.perf_counter() - started
+            audio_values = np.asarray(audio, dtype=np.float32).reshape(-1)
+            filename = f"{case_name}__{mode_name}__seed{seed}.wav"
+            audio_path = output_dir / filename
+            sf.write(audio_path, audio_values, int(sample_rate), subtype="PCM_16")
+            row = {
+                "case": case_name,
+                "family": case.family,
+                "text": case.text,
+                "mode": mode_name,
+                "seed": seed,
+                "elapsed_sec": elapsed,
+                "audio_path": str(audio_path),
+                **current_semantic,
+                **_audio_metrics(audio_values, int(sample_rate)),
+            }
+            manifest.append(row)
+            print(
+                f"[render] {case_name}/{mode_name}/seed{seed}: "
+                f"tokens={row.get('token_count')} duration={row['duration_sec']:.3f}s "
+                f"run={row.get('longest_equal_run')} -> {audio_path.name}"
+            )
+    finally:
+        decoder_class.infer_panel = original_infer_panel
+
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "generated_at": datetime.now().astimezone().isoformat(),
+                "device": args.device,
+                "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+                "max_sec": args.max_sec,
+                "samples": manifest,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    print(f"[render] manifest={manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tts/first_sentence_audio_cache.py
+++ b/tts/first_sentence_audio_cache.py
@@ -38,6 +38,7 @@ _KEY_FIELDS = (
 )
 
 _CACHE_SCHEMA = "first_sentence_audio_cache.v1"
+_SYNTHESIS_REVISION = "gsv_static_kv_mask_semantic_guard.v1"
 
 
 def _portable_basename(value: Any) -> str:
@@ -75,6 +76,10 @@ class FirstSentenceAudioCache:
             output_language = "en" if TTS_OUTPUT_LANGUAGE == "英文" else "ja"
         return {
             "text": text,
+            # Audio produced before this decoder invariant/guard revision may
+            # already contain a collapsed long vowel.  Keep it out of the new
+            # path without deleting user files or scanning the cache tree.
+            "synthesis_revision": _SYNTHESIS_REVISION,
             "tts_output_language": output_language,
             "gpt_model": TTS_GPT_MODEL_PATH,
             "sovits_model": TTS_SOVITS_MODEL_PATH,

--- a/tts/semantic_stability.py
+++ b/tts/semantic_stability.py
@@ -1,0 +1,134 @@
+"""Model-agnostic admission checks for GPT-SoVITS semantic candidates.
+
+The decoder samples discrete semantic tokens before SoVITS/BigVGAN renders
+audio.  A collapsed candidate must be rejected at this boundary: once it is
+rendered, a repeated token run becomes the very long vowel/noise that can hide
+the rest of an utterance.
+
+The checks intentionally use only sequence structure and a phone-relative
+budget.  They do not encode checkpoint-specific token IDs or words.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class SemanticCandidateAssessment:
+    accepted: bool
+    reasons: tuple[str, ...]
+    token_count: int
+    longest_equal_run: int
+    longest_periodic_run: int
+    periodic_run_period: int
+    top_token_ratio: float
+    soft_token_budget: int
+
+
+class SemanticGenerationError(RuntimeError):
+    """Raised when every bounded semantic-generation attempt collapses."""
+
+
+def _longest_equal_run(tokens: Sequence[int]) -> int:
+    best = 0
+    current = 0
+    previous = None
+    for token in tokens:
+        if token == previous:
+            current += 1
+        else:
+            previous = token
+            current = 1
+        best = max(best, current)
+    return best
+
+
+def _longest_periodic_run(
+    tokens: Sequence[int], max_period: int = 8
+) -> tuple[int, int]:
+    best_run = 0
+    best_period = 0
+    for period in range(1, max_period + 1):
+        current = 0
+        for index in range(period, len(tokens)):
+            if tokens[index] == tokens[index - period]:
+                current = current + 1 if current else period + 1
+            else:
+                current = 0
+            if current > best_run:
+                best_run = current
+                best_period = period
+    return best_run, best_period
+
+
+def assess_semantic_candidate(
+    tokens: Sequence[int],
+    *,
+    target_phone_count: int,
+    max_generation_tokens: int,
+) -> SemanticCandidateAssessment:
+    """Decide whether a semantic sequence is safe to send to the vocoder.
+
+    Thresholds were selected against the paired-seed filler stress cohort.  A
+    candidate is not rejected for length alone: long, diverse speech remains
+    valid.  Length becomes a signal only when it coincides with repetition or
+    concentration, which keeps the guard independent of language and token ID.
+    """
+
+    clean_tokens = [int(token) for token in tokens]
+    token_count = len(clean_tokens)
+    phone_count = max(1, int(target_phone_count))
+    configured_limit = max(1, int(max_generation_tokens))
+    soft_token_budget = min(
+        configured_limit,
+        max(96, int(math.ceil(phone_count * 4.0))),
+    )
+
+    if not clean_tokens:
+        return SemanticCandidateAssessment(
+            accepted=False,
+            reasons=("empty_candidate",),
+            token_count=0,
+            longest_equal_run=0,
+            longest_periodic_run=0,
+            periodic_run_period=0,
+            top_token_ratio=0.0,
+            soft_token_budget=soft_token_budget,
+        )
+
+    counts = Counter(clean_tokens)
+    equal_run = _longest_equal_run(clean_tokens)
+    periodic_run, periodic_period = _longest_periodic_run(clean_tokens)
+    top_token_ratio = max(counts.values()) / token_count
+    equal_run_ratio = equal_run / token_count
+
+    reasons: list[str] = []
+    if equal_run >= 48 or (equal_run >= 32 and equal_run_ratio >= 0.18):
+        reasons.append("equal_token_collapse")
+    if periodic_run >= 64:
+        reasons.append("periodic_token_collapse")
+    if token_count >= 64 and top_token_ratio >= 0.55:
+        reasons.append("token_concentration")
+    if token_count > soft_token_budget and (
+        # A 20-token identical run is roughly 0.4 s at the 50 Hz semantic
+        # rate.  It is only actionable here when the complete candidate has
+        # also exceeded its phone-relative budget; either signal alone is
+        # intentionally accepted.
+        top_token_ratio >= 0.35 or equal_run >= 20 or periodic_run >= 32
+    ):
+        reasons.append("length_with_repetition")
+
+    return SemanticCandidateAssessment(
+        accepted=not reasons,
+        reasons=tuple(reasons),
+        token_count=token_count,
+        longest_equal_run=equal_run,
+        longest_periodic_run=periodic_run,
+        periodic_run_period=periodic_period,
+        top_token_ratio=top_token_ratio,
+        soft_token_budget=soft_token_budget,
+    )


### PR DESCRIPTION
## 中文摘要

> 给中文审阅者的速览；下方英文正文保留完整实验数据。

- **问题**：GPT-SoVITS 在静态 KV cache 和 CUDA Graph 路径下可能读取尚未写入或仅用于对齐的缓存位置，导致语义 token 坍缩为长串重复元音，最终产生失控的填充音。
- **修复**：屏蔽无效 KV 位置；从真实 prompt 长度连续生成；bucket 溢出时保留完整条件上下文；在进入 SoVITS/BigVGAN 前拦截与 token ID 无关的坍缩候选，并只允许一次有界、可观测的重试；同时隔离 Graph capture 的随机数状态并使修复前首句音频缓存失效。
- **实验结果**：固定 660 次、同 GPU/模型/文本/种子的对照中，最终 Graph+static、static、dynamic 三条路径的异常均从修复前的 24/220、24/220、14/220 降为 0/220；220/220 组语义流与保护决策保持一致。示例语音从 9.77 秒、最长 192 个重复 token，改善为 5.04 秒、最长重复 10 个 token，ASR 能保留完整续句。
- **性能与审阅重点**：Graph/static 中位延迟仍为 108.4 ms，约比非 Graph 路径快 2.75 倍。建议重点审阅保护规则的误杀风险、单次重试的可观测性、随机数隔离以及缓存版本失效是否完整。
- **验证**：50 项公开 TTS/backend 定向测试、语义保护 fail-closed 测试、第三方来源门禁、源码发布门禁、Python 编译与 diff 检查均通过。

关联问题：#21。

## Summary

- mask unwritten and CUDA-Graph alignment-gap KV positions while preserving fixed graph shapes
- generate contiguously from the real prompt length and preserve full conditioning context on bucket overflow
- reject token-ID-independent collapsed semantic candidates before SoVITS/BigVGAN, with one bounded observable retry
- isolate graph capture from sampling RNG and invalidate pre-fix first-sentence audio-cache identities
- add paired-seed stability probes, real-audio rendering support, static/dynamic parity tests, and guard/cache regression tests

## Evidence

A fixed 660-trial filler-heavy paired-seed cohort (same physical GPU, model hashes, texts, seeds, and 400-token cap) changed from:

| Phase | Graph + static | Static | Dynamic |
|---|---:|---:|---:|
| Before | 24/220 | 24/220 | 14/220 |
| KV fix only | 14/220 | 14/220 | 14/220 |
| Final guarded path | 0/220 | 0/220 | 0/220 |

After the KV fix, Graph/static and static/dynamic semantic streams match exactly for 220/220 paired case/seed combinations. The final guard makes the same retry decision in all 220/220 pairs.

For `うーん……正直、まだ完全には分からないわ。` at seed 2001:

- before: 243 semantic tokens, longest equal-token run 192, 9.77 s WAV, ASR only `うーん。`
- after: 125 tokens, longest run 10, 5.04 s WAV, ASR retains the complete continuation

Normal median T2S latency on the final full matrix is 108.4 ms Graph/static, 300.0 ms static, and 297.8 ms dynamic; Graph remains about 2.75x lower-latency than non-Graph paths.

## Validation

- `50 passed` targeted public TTS/backend regression suite
- direct project-environment semantic guard retry/fail-closed tests passed
- third-party provenance release gate passed
- deterministic source-release gate passed (0 errors, 0 warnings)
- Python compilation and `git diff --check` passed

Closes #21
