### PR TITLE
fix(work): keep narration truthful across steer

### DIFF
--- a/agent_host/adapters/codex_app_server.py
+++ b/agent_host/adapters/codex_app_server.py
@@ -1183,27 +1183,53 @@ class CodexAppServerAdapter:
         )
         name = self._tool_name(safe_item_type, item)
         if method == "item/started":
-            return [
-                self._event(
-                    active,
-                    "tool.call",
-                    {
-                        "name": name,
-                        "item_id": item_id,
-                        "input": self._tool_input(safe_item_type, item),
-                    },
+            tool_input = self._tool_input(safe_item_type, item)
+            call_payload: dict[str, Any] = {
+                "tool": name,
+                "name": name,
+                "item_id": item_id,
+                "input": tool_input,
+            }
+            if isinstance(tool_input, dict):
+                command = str(tool_input.get("command") or "").strip()
+                title = " ".join(str(tool_input.get("title") or "").split())[:240]
+                changes = tool_input.get("changes")
+                if command:
+                    call_payload["command"] = command[:2000]
+                if title:
+                    call_payload["title"] = title
+                if isinstance(changes, list):
+                    call_payload["changes"] = changes
+            events = []
+            direction = self._reported_tool_direction(safe_item_type, tool_input)
+            if direction:
+                events.append(
+                    self._event(
+                        active,
+                        "assistant.update",
+                        {
+                            "text": direction,
+                            "source": "codex_native_tool_title",
+                            "explicit": False,
+                            "status": "reported_direction",
+                        },
+                    )
                 )
-            ]
+            events.append(self._event(active, "tool.call", call_payload))
+            return events
         success = self._item_succeeded(item)
         if not success:
             state.tool_failures += 1
         result_payload: dict[str, Any] = {
+            "tool": name,
             "name": name,
             "item_id": item_id,
             "success": success,
             "status": str(item.get("status") or ""),
             "output": self._tool_output(item),
         }
+        if safe_item_type == "commandExecution":
+            result_payload["exit_code"] = item.get("exitCode")
         if safe_item_type == "fileChange":
             result_payload["changes"] = self._file_changes(item)
         events = [
@@ -1504,6 +1530,16 @@ class CodexAppServerAdapter:
         if item_type == "fileChange":
             return {"changes": CodexAppServerAdapter._file_changes(item)}
         return item.get("arguments") or item.get("query") or {}
+
+    @staticmethod
+    def _reported_tool_direction(item_type: str, tool_input: Any) -> str:
+        """Return only the native human-facing title, never code or tool output."""
+
+        if item_type in {"commandExecution", "fileChange"} or not isinstance(
+            tool_input, dict
+        ):
+            return ""
+        return " ".join(str(tool_input.get("title") or "").split())[:240]
 
     @staticmethod
     def _file_changes(item: dict[str, Any]) -> list[dict[str, str]]:

--- a/server/handlers/work_activity_handler.py
+++ b/server/handlers/work_activity_handler.py
@@ -244,11 +244,6 @@ class WorkActivityCoordinator:
                 phase="Intake",
                 progress=10,
                 force=True,
-                # The Host knows which bounded goal it just dispatched even
-                # before the Provider reports an implementation milestone.
-                # Surface that one truthful direction so a long cold start is
-                # not two minutes of silence; results remain receipt-owned.
-                narration_keypoint="directional_progress",
             )
             return
 
@@ -831,6 +826,7 @@ class WorkActivityCoordinator:
         state["semantic_explicit"] = fact.explicit
         state["semantic_verified"] = fact.verified
         state["semantic_milestone"] = fact.milestone
+        state["semantic_evidence"] = fact.evidence
         return True
 
     @staticmethod
@@ -1495,8 +1491,23 @@ class WorkActivityCoordinator:
                 {
                     "narration_keypoint": narration_keypoint,
                     **(
-                        {"semantic_milestone": str(state.get("semantic_milestone") or "")}
-                        if semantic and state.get("semantic_milestone")
+                        {
+                            **(
+                                {
+                                    "semantic_milestone": str(
+                                        state.get("semantic_milestone") or ""
+                                    )
+                                }
+                                if state.get("semantic_milestone")
+                                else {}
+                            ),
+                            "semantic_source": str(state.get("semantic_source") or ""),
+                            "semantic_verified": state.get("semantic_verified") is True,
+                            "semantic_evidence": str(
+                                state.get("semantic_evidence") or "reported"
+                            ),
+                        }
+                        if semantic and not semantic_candidate
                         else {}
                     ),
                     **(
@@ -2001,9 +2012,11 @@ class WorkActivityCoordinator:
                     label="report" if semantic else "stream",
                     text=self._trim(text, 110),
                     detail=(
-                        "provider update; not terminal"
+                        "reported direction; not verified"
                         if semantic_candidate
-                        else "semantic"
+                        else "Host-observed semantic evidence"
+                        if semantic and state.get("semantic_verified") is True
+                        else "provider-reported semantic evidence; not verified"
                         if semantic
                         else "streaming"
                     ),

--- a/server/task_lookup.py
+++ b/server/task_lookup.py
@@ -562,18 +562,21 @@ def current_status_facts(
     stage_zh = stages_zh.get(stage_key, stages_zh.get(execution, stage_key or "未知"))
     stage_ja = stages_ja.get(stage_key, stages_ja.get(execution, stage_key or "不明"))
 
-    milestones = row.get("activity_milestones")
-    milestones = milestones if isinstance(milestones, dict) else {}
-    milestone_kind, milestone_fact = _latest_status_milestone(milestones)
+    milestones, direction, _steering = _current_status_evidence(row)
+    (
+        milestone_kind,
+        milestone_fact,
+        milestone_verified,
+        milestone_source,
+        _milestone_observed_at,
+    ) = _latest_status_milestone(milestones)
     terminal_fact = _terminal_status_fact(
         row,
         display_language=display_language,
         milestone_fact=milestone_fact,
     )
     recent = terminal_fact or milestone_fact
-    direction = " ".join(
-        str(row.get("activity_direction_summary") or "").split()
-    )[:360]
+    direction = direction[:360]
     direction_only = bool(
         direction
         and not recent
@@ -592,6 +595,9 @@ def current_status_facts(
         else ""
     )
     recent_source = recent or (direction if direction_only else "")
+    recent_verified = bool(terminal_fact) or bool(
+        milestone_fact and milestone_verified
+    )
     recent_zh = _localized_status_fact(
         recent_source,
         kind=recent_kind,
@@ -643,12 +649,24 @@ def current_status_facts(
     elif execution in {"failed", "cancelled", "orphaned"}:
         next_zh, next_ja = "处理失败原因后再决定是否重试", "失敗原因を確認してから再試行を判断します"
     elif execution in {"queued", "running"}:
-        if "validation" in milestones:
-            next_zh, next_ja = "继续收口剩余工作并形成终态报告", "残作業をまとめ、最終報告を作ります"
-        elif "capability" in milestones:
-            next_zh, next_ja = "验证已经实现的能力并报告结果", "実装済みの機能を検証し、結果を報告します"
-        elif "design" in milestones:
-            next_zh, next_ja = "按已确认的方案继续实现", "確認済みの方針に沿って実装を続けます"
+        if milestone_kind == "validation":
+            next_zh, next_ja = (
+                ("继续收口剩余工作并形成终态报告", "残作業をまとめ、最終報告を作ります")
+                if milestone_verified
+                else ("核对执行端报告的验证结果并继续收口", "報告された検証結果を確認して仕上げます")
+            )
+        elif milestone_kind == "capability":
+            next_zh, next_ja = (
+                ("验证已经实现的能力并报告结果", "実装済みの機能を検証し、結果を報告します")
+                if milestone_verified
+                else ("验证执行端报告的能力是否确实实现", "報告された機能が実際に動くか検証します")
+            )
+        elif milestone_kind == "design":
+            next_zh, next_ja = (
+                ("按已确认的方案继续实现", "確認済みの方針に沿って実装を続けます")
+                if milestone_verified
+                else ("核对执行端报告的方向并继续实现", "報告された方針を確認しながら実装を続けます")
+            )
         else:
             next_zh, next_ja = "形成可确认的实现方案并继续实现", "確認できる実装方針を固めて作業を続けます"
     elif completion == "complete":
@@ -673,12 +691,13 @@ def current_status_facts(
         "next_zh": next_zh,
         "next_ja": next_ja,
         "fact_kind": fact_kind,
+        "fact_verified": "true" if recent_verified else "false",
         "fact_source": (
             "terminal_outcome"
             if fact_kind == "terminal_result"
-            else "provider_direction"
+            else str(row.get("activity_direction_source") or "provider_direction")
             if fact_kind == "direction"
-            else "activity_milestone"
+            else milestone_source or "activity_milestone"
             if fact_kind
             else "none"
         ),
@@ -708,6 +727,10 @@ def render_current_status_facts(
     has_result = str(facts.get("fact_kind") or "") != ""
     direction_only = str(facts.get("direction_only") or "").lower() == "true"
     has_blocker = blocker_zh != "没有已知阻碍"
+    reported_result = (
+        has_result
+        and str(facts.get("fact_verified") or "false").lower() != "true"
+    )
 
     if stage_key in {"queued"}:
         display = f"还在等待开始，目前没有发现阻碍；下一步会{next_zh}。"
@@ -719,6 +742,12 @@ def render_current_status_facts(
         elif direction_only:
             display = f"还在处理中，当前执行方向是：{recent_zh}；这还不是完成结果，目前没有发现阻碍。"
             voice_ja = "まだ作業中よ。進め方は更新されていて、内容は画面に出してある。まだ完了報告ではないけど、今のところ問題はないわ。"
+        elif reported_result and has_blocker:
+            display = f"还在处理中，目前收到的执行报告是：{recent_zh}；这还不是宿主确认的结果，而且{blocker_zh}，接下来会{next_zh}。"
+            voice_ja = f"まだ作業中よ。実行側からは{recent_ja}と報告されているけれど、まだホスト確認済みの結果ではなく、{blocker_ja}。次は{next_ja}。"
+        elif reported_result:
+            display = f"还在处理中，目前收到的执行报告是：{recent_zh}；这还不是宿主确认的结果，目前没有发现阻碍。"
+            voice_ja = f"まだ作業中よ。実行側からは{recent_ja}と報告されているけれど、まだホスト確認済みの結果ではないわ。今のところ問題はない。"
         elif has_result and has_blocker:
             display = f"还在处理中，最近确认的是：{recent_zh}；不过{blocker_zh}，接下来会{next_zh}。"
             voice_ja = f"まだ作業中よ。{recent_ja}。ただ、{blocker_ja}。次は{next_ja}。"
@@ -730,8 +759,20 @@ def render_current_status_facts(
             display = f"还在处理“{title}”。暂时没有新的可确认成果，也没有发现阻碍；我会{next_zh}，有验证结果就告诉你。"
             voice_ja = f"「{title}」を進めているところよ。確認できる新しい成果も問題も、今のところ出ていない。{next_ja}から、検証結果が出たら知らせるわ。"
     elif stage_key in {"waiting_for_user", "stalled", "cancelling"} or has_blocker:
-        recent_clause_zh = f"目前确认到的是：{recent_zh}；" if has_result else ""
-        recent_clause_ja = f"ここまでに{recent_ja}は確認できているけれど、" if has_result else ""
+        recent_clause_zh = (
+            f"目前收到的执行报告是：{recent_zh}，但尚未由宿主确认；"
+            if reported_result
+            else f"目前确认到的是：{recent_zh}；"
+            if has_result
+            else ""
+        )
+        recent_clause_ja = (
+            f"実行側からは{recent_ja}と報告されているけれど、まだホスト確認済みではなく、"
+            if reported_result
+            else f"ここまでに{recent_ja}は確認できているけれど、"
+            if has_result
+            else ""
+        )
         display = f"这件事现在停在需要处理的环节。{recent_clause_zh}{blocker_zh}；接下来会{next_zh}。"
         voice_ja = f"今はここで止まっているわ。{recent_clause_ja}{blocker_ja}。次は{next_ja}。"
     elif stage_key in {"review", "succeeded", "terminal", "failed", "cancelled"}:
@@ -827,7 +868,7 @@ def status_query_narration_note(
     *,
     session_id: str = "",
 ) -> dict[str, Any]:
-    """Project one resolved WorkItem into verified Narrator evidence.
+    """Project one resolved WorkItem into authority-labelled Narrator evidence.
 
     Lookup has already selected the WorkItem before this function runs.  The
     resulting note deliberately retains Provider prose as evidence: it is the
@@ -845,12 +886,15 @@ def status_query_narration_note(
         str(row.get("completion_rationale") or "").split()
     )[:400]
 
-    milestones = row.get("activity_milestones")
-    milestones = milestones if isinstance(milestones, dict) else {}
-    milestone_kind, milestone_summary = _latest_status_milestone(milestones)
-    direction = " ".join(
-        str(row.get("activity_direction_summary") or "").split()
-    )[:420]
+    milestones, direction, steering = _current_status_evidence(row)
+    (
+        milestone_kind,
+        milestone_summary,
+        milestone_verified,
+        milestone_source,
+        milestone_observed_at,
+    ) = _latest_status_milestone(milestones)
+    direction = direction[:420]
 
     from agent_host.provider_progress import split_progress_milestones
 
@@ -858,16 +902,31 @@ def status_query_narration_note(
         str(row.get("terminal_summary") or "")
     )
     visible_terminal = " ".join(visible_terminal.split())[:600]
+    outcome_verdict = row.get("outcome_verdict")
+    outcome_verdict = outcome_verdict if isinstance(outcome_verdict, dict) else {}
     is_terminal = execution in {"succeeded", "failed", "cancelled", "orphaned"}
+    fact_verified = False
+    fact_source = ""
+    fact_observed_at = 0.0
     if is_terminal:
         fact_kind = "terminal_result"
         fact_summary = visible_terminal or milestone_summary
+        fact_verified = outcome_verdict.get("verified") is True
+        fact_source = "host_outcome" if fact_verified else "provider_terminal"
+        fact_observed_at = milestone_observed_at if not visible_terminal else 0.0
     elif milestone_summary:
         fact_kind = milestone_kind
         fact_summary = milestone_summary
+        fact_verified = milestone_verified
+        fact_source = milestone_source
+        fact_observed_at = milestone_observed_at
     elif direction:
         fact_kind = "direction"
         fact_summary = direction
+        fact_source = str(row.get("activity_direction_source") or "provider_direction")
+        fact_observed_at = _status_observed_at(
+            row.get("activity_last_directional_update_at")
+        )
     else:
         fact_kind = ""
         fact_summary = ""
@@ -886,12 +945,19 @@ def status_query_narration_note(
     if fact_summary:
         signals.append(
             {
-                "label": "direction" if fact_kind == "direction" else "report",
+                "label": (
+                    "direction"
+                    if fact_kind == "direction"
+                    or (fact_kind == "design" and not fact_verified)
+                    else "report"
+                ),
                 "text": fact_summary[:420],
                 "detail": (
                     "unverified reported execution direction"
                     if fact_kind == "direction"
-                    else f"verified {fact_kind} evidence"
+                    else f"Host-verified {fact_kind} evidence"
+                    if fact_verified
+                    else f"reported {fact_kind} evidence; not Host-verified"
                 ),
                 "kind": "status",
             }
@@ -906,8 +972,6 @@ def status_query_narration_note(
             }
         )
 
-    outcome_verdict = row.get("outcome_verdict")
-    outcome_verdict = outcome_verdict if isinstance(outcome_verdict, dict) else {}
     work_item_id = str(row.get("work_item_id") or "").strip()
     attempt_id = str(
         row.get("attempt_id") or row.get("current_attempt_id") or ""
@@ -925,7 +989,12 @@ def status_query_narration_note(
         "phase": "Checkpoint",
         "importance": "important",
         "title": title,
-        "summary": fact_summary or title,
+        "summary": fact_summary
+        or (
+            "No semantic milestone has been reported for the current instruction revision."
+            if _steering_has_freshness_fence(steering)
+            else title
+        ),
         "signals": signals,
         "metadata": {
             "status_query": True,
@@ -944,6 +1013,11 @@ def status_query_narration_note(
                 "uncertainty": uncertainty,
                 "completion_rationale": rationale,
                 "fact_kind": fact_kind,
+                "fact_verified": fact_verified,
+                "fact_source": fact_source,
+                "fact_observed_at": fact_observed_at,
+                "steering_state": str(steering.get("state") or ""),
+                "steering_revision": int(steering.get("revision") or 0),
             },
         },
     }
@@ -992,22 +1066,84 @@ def _terminal_status_fact(
 
 def _latest_status_milestone(
     milestones: dict[str, Any],
-) -> tuple[str, str]:
-    """Return the latest ledger milestone, never an unconfirmed candidate."""
+) -> tuple[str, str, bool, str, float]:
+    """Return the latest ledger milestone together with its evidence strength."""
 
-    rows: list[tuple[float, str, str]] = []
+    rows: list[tuple[float, str, str, bool, str]] = []
     for key, value in milestones.items():
         kind = str(key or "").strip().lower()
         if kind not in {"design", "diagnostic", "capability", "validation"} or not isinstance(value, dict):
             continue
         summary = " ".join(str(value.get("summary") or "").split())
         if summary:
-            rows.append((float(value.get("observedAt") or 0.0), kind, summary))
+            rows.append(
+                (
+                    _status_observed_at(value.get("observedAt")),
+                    kind,
+                    summary,
+                    value.get("verified") is True,
+                    str(value.get("source") or ""),
+                )
+            )
     rows.sort(reverse=True)
     if not rows:
-        return "", ""
-    _observed_at, kind, summary = rows[0]
-    return kind, summary
+        return "", "", False, "", 0.0
+    observed_at, kind, summary, verified, source = rows[0]
+    return kind, summary, verified, source, observed_at
+
+
+def _current_status_evidence(
+    row: dict[str, Any],
+) -> tuple[dict[str, Any], str, dict[str, Any]]:
+    """Select the causal evidence view for the current steering instruction."""
+
+    raw_milestones = row.get("activity_milestones")
+    milestones = (
+        dict(raw_milestones) if isinstance(raw_milestones, dict) else {}
+    )
+    direction = " ".join(
+        str(row.get("activity_direction_summary") or "").split()
+    )
+    steering = (
+        dict(row.get("activity_steering"))
+        if isinstance(row.get("activity_steering"), dict)
+        else {}
+    )
+    if not _steering_has_freshness_fence(steering):
+        return milestones, direction, steering
+
+    cutoff = _status_observed_at(steering.get("observedAt"))
+    if cutoff <= 0.0:
+        return {}, "", steering
+    current_milestones = {
+        str(key): dict(value)
+        for key, value in milestones.items()
+        if isinstance(value, dict)
+        and _status_observed_at(value.get("observedAt")) > cutoff
+    }
+    direction_observed_at = _status_observed_at(
+        row.get("activity_last_directional_update_at")
+    )
+    if direction_observed_at <= cutoff:
+        direction = ""
+    return current_milestones, direction, steering
+
+
+def _steering_has_freshness_fence(steering: dict[str, Any]) -> bool:
+    return str(steering.get("state") or "").strip().lower() in {
+        "queued",
+        "applied",
+        "cancel_pending",
+        "restarted",
+        "replaced",
+    }
+
+
+def _status_observed_at(value: Any) -> float:
+    try:
+        return max(0.0, float(value or 0.0))
+    except (TypeError, ValueError):
+        return 0.0
 
 
 # ── facts for the answering pass ─────────────────────────────────────────────

--- a/server/work_narration_governor.py
+++ b/server/work_narration_governor.py
@@ -30,9 +30,8 @@ NARRATION_KEYPOINTS = frozenset(
     }
 )
 # These events open an observer decision window.  They do not all force the
-# character to speak: first-tool facts are useful on the Slice but contain no
-# new task knowledge on their own. New intake producers classify the explicit
-# Host-dispatched goal as directional progress instead of a mechanical event.
+# character to speak: intake and first-tool facts are useful on the Slice but
+# contain no new Provider-authored task knowledge on their own.
 _NARRATION_TRIGGERS = NARRATION_KEYPOINTS | {
     "directional_progress",
     "semantic_progress",

--- a/server/work_observer.py
+++ b/server/work_observer.py
@@ -326,6 +326,20 @@ class WorkObserverCoordinator:
         after it is stale.  Terminal truth is never consumed here.
         """
 
+        return self._supersede_nonterminal(
+            work_item_id,
+            reason="status query",
+        )
+
+    def supersede_for_steer(self, work_item_id: str) -> int:
+        """Retire nonterminal narration from the superseded instruction."""
+
+        return self._supersede_nonterminal(
+            work_item_id,
+            reason="steer checkpoint",
+        )
+
+    def _supersede_nonterminal(self, work_item_id: str, *, reason: str) -> int:
         target = str(work_item_id or "").strip()
         if not target:
             return 0
@@ -343,7 +357,8 @@ class WorkObserverCoordinator:
                 task.cancel()
         if consumed:
             logger.info(
-                "[WORK-NARRATION] status query superseded %d pending update(s) for %s",
+                "[WORK-NARRATION] %s superseded %d pending update(s) for %s",
+                reason,
                 consumed,
                 target,
             )
@@ -479,6 +494,13 @@ class WorkObserverCoordinator:
         if self._closing or self._closed or self._queue is None:
             return
         note = dict(params or {})
+        metadata = note.get("metadata") if isinstance(note.get("metadata"), dict) else {}
+        if str(metadata.get("steering_stage") or "").strip().lower() in {
+            "steer_queued",
+            "steer_applied",
+        }:
+            work_item_id, _attempt_id = self._work_identity(note)
+            self.supersede_for_steer(work_item_id)
         if self._observer_policy(note) == "silent":
             self._trace_drop(note, "observer_policy_silent")
             return
@@ -1086,9 +1108,8 @@ class WorkObserverCoordinator:
                 metadata.get("narration_merged_count") or 0
             ),
         }
-        # Legacy intake snapshots and the first tool are useful visual/audit
-        # facts but contain no new direction. New intake producers explicitly
-        # mark the Host-dispatched bounded goal as directional_progress.
+        # Intake snapshots and the first tool are useful visual/audit facts but
+        # contain no Provider-authored direction or semantic result.
         if keypoints and set(keypoints).issubset({"run_started", "first_tool"}):
             return {
                 **annotated,

--- a/server/work_observer_llm.py
+++ b/server/work_observer_llm.py
@@ -38,7 +38,8 @@ Rules:
 - Prioritize design decisions and their reasons, completed user-visible capabilities, and validation results/problems over filenames, commands, and tool actions.
 - For semantic progress summaries that explain task content, prefer "speak" with one short sentence. The user should hear meaningful progress, not only the final result.
 - A current_note signal with label "report" is semantic progress when it says the provider found, identified, confirmed, compared, filtered, summarized, or otherwise learned something about the task content.
-- When current_note.progress_context.status_query is true, the person explicitly asked for this WorkItem's status. Answer once in character from the supplied Host lifecycle fields and factual report/direction evidence. Translate or naturally paraphrase Provider prose into display_language; do not merely name its semantic class, stay silent, or expose the field names. Preserve the distinction between an unverified direction and a verified result.
+- When current_note.progress_context.status_query is true, the person explicitly asked for this WorkItem's status. Answer once in character from the supplied Host lifecycle fields and factual report/direction evidence. Translate or naturally paraphrase Provider prose into display_language; do not merely name its semantic class, stay silent, or expose the field names. status_facts.fact_verified is authoritative: when it is false, attribute the content as a current execution report or direction and never turn it into a Host-verified result.
+- semantic_verified=false or semantic_evidence=reported means the milestone is Provider-reported evidence, not a Host-observed result. Preserve that modality even when its summary uses confident wording.
 - A directional_progress note is unverified reported intent, not an outcome fact. It may still be worth one short spoken update when it tells the person what is being inspected, built, changed, or deliberately validated. Preserve its modality: say "正在/接下来/会确保" (or the equivalent in display_language), never "已经实现/验证通过" unless a later factual milestone says so.
 - When current_note.progress_context names directional_progress or semantic_progress, always provide one localized display_text candidate even if you choose a non-speaking action. The Host owns cadence and may promote the first concrete update; empty text would make that deterministic policy impossible.
 - Initial plans and future intent do not establish completion authority, but a newly selected execution direction is useful task awareness. Speak it when it adds a concrete big-picture direction; stay silent for generic promises such as "I am working on it", mechanical tool narration, or a rephrasing of a recently spoken direction.
@@ -285,6 +286,8 @@ def _compact_note(note: dict[str, Any]) -> dict[str, Any]:
                 "directional_summary",
                 "directional_source",
                 "semantic_source",
+                "semantic_verified",
+                "semantic_evidence",
                 "permission_diagnostic",
                 "permission_actionable",
                 "permission_retry_required",

--- a/server/work_semantic_progress.py
+++ b/server/work_semantic_progress.py
@@ -340,6 +340,8 @@ def _is_validation_command(command: str) -> bool:
 def _tool_succeeded(payload: dict[str, Any]) -> bool:
     if "ok" in payload:
         return payload.get("ok") is True
+    if "success" in payload:
+        return payload.get("success") is True
     if payload.get("exit_code") is not None:
         try:
             return int(payload.get("exit_code")) == 0

--- a/tests/test_codex_app_server_adapter.py
+++ b/tests/test_codex_app_server_adapter.py
@@ -278,6 +278,16 @@ def test_sdk_adapter_maps_thread_turn_events_and_terminal_truth() -> None:
         assert event_types.count("tool.call") == 1
         assert event_types.count("tool.result") == 2
         assert all(event.run_id == "run-1" for event in events)
+        command_call = next(event for event in events if event.type == "tool.call")
+        assert command_call.payload["tool"] == "shell"
+        assert command_call.payload["command"] == "python verify.py"
+        command_result = next(
+            event
+            for event in events
+            if event.type == "tool.result" and event.payload["name"] == "shell"
+        )
+        assert command_result.payload["success"] is True
+        assert command_result.payload["exit_code"] == 0
         file_result = next(
             event
             for event in events
@@ -409,6 +419,85 @@ def test_completed_codex_commentary_becomes_an_unverified_direction_update() -> 
         assert result.result == "The integration is complete."
 
     with tempfile.TemporaryDirectory(prefix="amadeus-codex-direction-") as temp_dir:
+        asyncio.run(scenario(Path(temp_dir)))
+
+
+def test_dynamic_tool_title_becomes_a_bounded_reported_direction() -> None:
+    async def scenario(root: Path) -> None:
+        events = [
+            _Notification(
+                "item/started",
+                {
+                    "item": {
+                        "id": "dynamic-1",
+                        "type": "dynamicToolCall",
+                        "tool": "js",
+                        "arguments": {
+                            "code": "writeWorkspaceFile()",
+                            "title": "Updating the game for simultaneous two-player battle",
+                            "timeout_ms": 30_000,
+                        },
+                        "status": "inProgress",
+                    }
+                },
+            ),
+            _Notification(
+                "item/completed",
+                {
+                    "item": {
+                        "id": "dynamic-1",
+                        "type": "dynamicToolCall",
+                        "tool": "js",
+                        "status": "completed",
+                        "output": "pvz.html updated",
+                    }
+                },
+            ),
+            _Notification(
+                "item/completed",
+                {
+                    "item": {
+                        "id": "message-dynamic",
+                        "type": "agentMessage",
+                        "phase": "final_answer",
+                        "text": "The requested update is staged.",
+                    }
+                },
+            ),
+            _turn_completed("turn-dynamic", "completed"),
+        ]
+        adapter = CodexAppServerAdapter(
+            codex=_FakeCodex(
+                [_FakeThread("thread-dynamic", _FakeTurn("turn-dynamic", events))]
+            )
+        )
+        observed = []
+
+        async def emit(event) -> None:
+            observed.append(event)
+
+        result = await adapter.run(
+            _request(root, "Update the game", write=True),
+            "run-dynamic",
+            emit,
+        )
+
+        assert result.status == "done"
+        updates = [event for event in observed if event.type == "assistant.update"]
+        assert len(updates) == 1
+        assert updates[0].payload == {
+            "text": "Updating the game for simultaneous two-player battle",
+            "source": "codex_native_tool_title",
+            "explicit": False,
+            "status": "reported_direction",
+        }
+        call = next(event for event in observed if event.type == "tool.call")
+        assert call.payload["name"] == "js"
+        assert call.payload["title"] == updates[0].payload["text"]
+        assert call.payload["input"]["code"] == "writeWorkspaceFile()"
+        assert not any(event.type == "semantic.progress" for event in observed)
+
+    with tempfile.TemporaryDirectory(prefix="amadeus-codex-tool-title-") as temp_dir:
         asyncio.run(scenario(Path(temp_dir)))
 
 
@@ -1245,6 +1334,7 @@ def test_bootstrap_exposes_exactly_one_codex_transport() -> None:
 def _main() -> None:
     test_sdk_adapter_maps_thread_turn_events_and_terminal_truth()
     test_native_plan_becomes_an_early_reported_design_milestone()
+    test_dynamic_tool_title_becomes_a_bounded_reported_direction()
     test_unknown_and_collaboration_items_fail_closed_as_execution()
     test_windows_runtime_path_prefers_a_real_powershell_binary()
     test_sdk_runtime_config_isolated_from_codex_desktop_defaults()

--- a/tests/test_runtime_activity_snapshot.py
+++ b/tests/test_runtime_activity_snapshot.py
@@ -321,6 +321,127 @@ def test_verified_tool_fact_advances_semantic_clock_once() -> None:
     assert result["lastSemanticProgressAt"] == 5_010.0
 
 
+def test_status_query_tracks_the_current_steer_evidence_end_to_end() -> None:
+    snapshot = project_activity_event(
+        {},
+        _event(1, "run.created", at=10.0),
+        execution_status="running",
+        now=10.0,
+    )
+    snapshot = project_activity_event(
+        snapshot,
+        _event(
+            2,
+            "semantic.progress",
+            {
+                "milestone": "design",
+                "summary": "I will implement the old one-player design.",
+                "source": "provider_explicit_progress",
+                "verified": False,
+            },
+            at=12.0,
+        ),
+        execution_status="running",
+        now=12.0,
+    )
+    snapshot = project_activity_event(
+        snapshot,
+        _event(
+            3,
+            "run.status",
+            {
+                "status": "running",
+                "stage": "steer_queued",
+                "revision": 1,
+                "replaces_revision": 0,
+            },
+            at=20.0,
+        ),
+        execution_status="running",
+        now=20.0,
+    )
+
+    def status_note(current: dict, *, now: float) -> dict:
+        fields = activity_report_fields(
+            current,
+            execution_status="running",
+            created_at=10.0,
+            started_at=10.0,
+            finished_at=None,
+            now=now,
+        )
+        return task_lookup.status_query_narration_note(
+            {
+                "work_item_id": "work-steer-freshness",
+                "attempt_id": "attempt-steer-freshness",
+                "title": "Build the game",
+                "execution": "running",
+                "completion": "unknown",
+                "attention": "none",
+                **fields,
+            }
+        )
+
+    stale = status_note(snapshot, now=21.0)
+    assert stale["metadata"]["semantic_milestone"] == ""
+    assert stale["metadata"]["status_facts"]["steering_revision"] == 1
+
+    snapshot = project_activity_event(
+        snapshot,
+        _event(
+            4,
+            "semantic.progress",
+            {
+                "milestone": "capability",
+                "summary": "The two-player controls are wired.",
+                "source": "provider_explicit_progress",
+                "verified": False,
+            },
+            at=30.0,
+        ),
+        execution_status="running",
+        now=30.0,
+    )
+    reported = status_note(snapshot, now=31.0)
+    assert reported["metadata"]["semantic_milestone"] == "capability"
+    assert reported["metadata"]["status_facts"]["fact_verified"] is False
+
+    snapshot = project_activity_event(
+        snapshot,
+        _event(
+            5,
+            "tool.call",
+            {
+                "tool": "command_execution",
+                "item_id": "validation-1",
+                "command": "python -m pytest tests/test_game.py",
+            },
+            at=40.0,
+        ),
+        execution_status="running",
+        now=40.0,
+    )
+    snapshot = project_activity_event(
+        snapshot,
+        _event(
+            6,
+            "tool.result",
+            {
+                "item_id": "validation-1",
+                "success": True,
+                "status": "completed",
+            },
+            at=41.0,
+        ),
+        execution_status="running",
+        now=41.0,
+    )
+    observed = status_note(snapshot, now=42.0)
+    assert observed["metadata"]["semantic_milestone"] == "validation"
+    assert observed["metadata"]["status_facts"]["fact_verified"] is True
+    assert observed["summary"] == "Project validation passed."
+
+
 def test_repeated_permission_fact_does_not_reset_clock_after_other_progress() -> None:
     permission_payload = {
         "capability": "tool.execute",
@@ -893,6 +1014,7 @@ def main() -> None:
     test_retrospective_permission_is_denied_activity_not_waiting_for_user()
     test_mechanical_events_do_not_reset_semantic_silence()
     test_verified_tool_fact_advances_semantic_clock_once()
+    test_status_query_tracks_the_current_steer_evidence_end_to_end()
     test_repeated_permission_fact_does_not_reset_clock_after_other_progress()
     test_staging_observation_is_bounded_to_the_attempt_namespace()
     test_report_refresh_combines_durable_activity_with_live_git_facts()

--- a/tests/test_task_lookup.py
+++ b/tests/test_task_lookup.py
@@ -687,7 +687,12 @@ def test_running_status_next_step_tracks_the_latest_semantic_phase() -> None:
         {
             **base,
             "activity_milestones": {
-                "design": {"summary": "Use one AUIP receipt loop.", "observedAt": 1}
+                "design": {
+                    "summary": "Use one AUIP receipt loop.",
+                    "source": "host.tool_observation",
+                    "verified": True,
+                    "observedAt": 1,
+                }
             },
         }
     )
@@ -697,6 +702,8 @@ def test_running_status_next_step_tracks_the_latest_semantic_phase() -> None:
             "activity_milestones": {
                 "capability": {
                     "summary": "Rejected moves can now recover once.",
+                    "source": "host.tool_observation",
+                    "verified": True,
                     "observedAt": 2,
                 }
             },

--- a/tests/test_work_narration_priority.py
+++ b/tests/test_work_narration_priority.py
@@ -885,6 +885,146 @@ def test_status_query_consumes_progress_but_never_terminal_truth() -> None:
     )
 
 
+def test_steer_checkpoint_retires_pending_pre_steer_narration() -> None:
+    async def scenario() -> None:
+        observer = WorkObserverCoordinator()
+        session = ObserverSession(
+            narration_id="work:work-steer:attempt:attempt-steer",
+            run_id="run-steer",
+            session_id="session-steer",
+            provider="future_provider",
+            work_item_id="work-steer",
+            attempt_id="attempt-steer",
+        )
+        observer._sessions[session.narration_id] = session
+        observer._narration_governor.observe(
+            {
+                **_note("The old design is ready to implement.", "semantic_progress"),
+                "run_id": session.narration_id,
+            },
+            output_busy=True,
+        )
+        observer._queue = asyncio.Queue()
+        checkpoint = {
+            "provider": "future_provider",
+            "run_id": session.run_id,
+            "session_id": session.session_id,
+            "phase": "Checkpoint",
+            "summary": "The new instruction is waiting at a safe boundary.",
+            "observer_policy": "silent",
+            "metadata": {
+                "work_item_id": session.work_item_id,
+                "attempt_id": session.attempt_id,
+                "steering_stage": "steer_queued",
+                "steering_revision": 1,
+            },
+        }
+
+        with patch.object(observer, "_supersede_pending_delivery", return_value=0):
+            await observer._on_work_note(Method.CHAT_WORK_NOTE, checkpoint)
+
+        assert not observer._narration_governor.has_pending(session.narration_id)
+        assert observer._queue.empty()
+
+    asyncio.run(scenario())
+
+
+def test_status_query_uses_only_current_steer_evidence_and_preserves_authority() -> None:
+    from server import task_lookup
+
+    old_design = "I will build the old one-player plan, then validate it."
+    base = {
+        "work_item_id": "work-status-freshness",
+        "attempt_id": "attempt-status-freshness",
+        "title": "Build the board",
+        "execution": "running",
+        "activity_phase": "working",
+        "completion": "unknown",
+        "attention": "none",
+        "activity_direction_summary": old_design,
+        "activity_last_directional_update_at": 12,
+        "activity_milestones": {
+            "design": {
+                "summary": old_design,
+                "source": "provider_explicit_progress",
+                "verified": False,
+                "observedAt": 10,
+            }
+        },
+        "activity_steering": {
+            "state": "queued",
+            "revision": 1,
+            "observedAt": 20,
+        },
+    }
+
+    stale = task_lookup.status_query_narration_note(base)
+    assert stale["metadata"]["semantic_milestone"] == ""
+    assert stale["metadata"]["directional_summary"] == ""
+    assert stale["metadata"]["status_facts"]["fact_kind"] == ""
+    assert stale["metadata"]["status_facts"]["steering_revision"] == 1
+    assert all(old_design not in str(signal.get("text") or "") for signal in stale["signals"])
+    stale_fallback = task_lookup.current_status_facts(base)
+    assert stale_fallback["fact_kind"] == ""
+    assert stale_fallback["fact_verified"] == "false"
+
+    current_row = {
+        **base,
+        "activity_milestones": {
+            **base["activity_milestones"],
+            "capability": {
+                "summary": "The two-player controls are now wired.",
+                "source": "provider_explicit_progress",
+                "verified": False,
+                "observedAt": 30,
+            },
+        },
+    }
+    reported = task_lookup.status_query_narration_note(current_row)
+    report_signal = next(
+        signal for signal in reported["signals"] if signal.get("label") == "report"
+    )
+    assert reported["metadata"]["semantic_milestone"] == "capability"
+    assert reported["metadata"]["status_facts"]["fact_verified"] is False
+    assert report_signal["detail"] == "reported capability evidence; not Host-verified"
+    reported_fallback = task_lookup.current_status_facts(current_row)
+    assert reported_fallback["fact_kind"] == "capability"
+    assert reported_fallback["fact_verified"] == "false"
+
+    verified_row = {
+        **current_row,
+        "activity_milestones": {
+            **current_row["activity_milestones"],
+            "capability": {
+                **current_row["activity_milestones"]["capability"],
+                "verified": True,
+            },
+        },
+    }
+    verified = task_lookup.status_query_narration_note(verified_row)
+    verified_signal = next(
+        signal for signal in verified["signals"] if signal.get("label") == "report"
+    )
+    assert verified["metadata"]["status_facts"]["fact_verified"] is True
+    assert verified_signal["detail"] == "Host-verified capability evidence"
+
+    rejected_row = {
+        **base,
+        "activity_steering": {
+            "state": "rejected",
+            "revision": 1,
+            "observedAt": 20,
+        },
+    }
+    rejected = task_lookup.status_query_narration_note(rejected_row)
+    assert rejected["metadata"]["semantic_milestone"] == "design"
+    assert rejected["metadata"]["status_facts"]["fact_verified"] is False
+    assert rejected["summary"] == old_design
+    rejected_fallback = task_lookup.current_status_facts(rejected_row)
+    assert rejected_fallback["fact_kind"] == "design"
+    assert rejected_fallback["fact_verified"] == "false"
+
+
 def test_explicit_status_query_reuses_the_existing_narrator_and_attempt_context() -> None:
     async def scenario() -> None:
         from server import task_lookup
@@ -981,5 +1121,7 @@ if __name__ == "__main__":
     test_terminal_voice_omits_exact_sentences_already_spoken_but_keeps_full_history()
     test_terminal_narrator_cannot_reuse_a_predecessor_attempt_from_chat()
     test_status_query_consumes_progress_but_never_terminal_truth()
+    test_steer_checkpoint_retires_pending_pre_steer_narration()
+    test_status_query_uses_only_current_steer_evidence_and_preserves_authority()
     test_explicit_status_query_reuses_the_existing_narrator_and_attempt_context()
     print("ok: narration prioritises semantic milestones and permission state changes")

--- a/tests/test_work_progress_monotonic.py
+++ b/tests/test_work_progress_monotonic.py
@@ -100,7 +100,7 @@ async def test_new_run_id_resets_the_clamp() -> None:
     print("ok: the monotonic clamp is per run and resets on a new run_id")
 
 
-async def test_run_intake_exposes_the_host_dispatched_goal_as_direction() -> None:
+async def test_run_intake_stays_on_the_work_surface_without_narration() -> None:
     coordinator = WorkActivityCoordinator()
     notes: list[dict[str, Any]] = []
 
@@ -120,9 +120,50 @@ async def test_run_intake_exposes_the_host_dispatched_goal_as_direction() -> Non
     note = notes[0]
     assert note["summary"] == "Render a monotonic progress bar."
     assert note["phase"] == "Intake"
-    assert note["metadata"]["narration_keypoint"] == "directional_progress"
+    assert "narration_keypoint" not in note["metadata"]
     assert "result" not in note["metadata"]
-    print("ok: bounded Host intake is a direction, not an invented result")
+    print("ok: bounded Host intake stays visible without becoming speech")
+
+
+async def test_first_provider_direction_after_intake_remains_narratable() -> None:
+    coordinator = WorkActivityCoordinator()
+    notes: list[dict[str, Any]] = []
+
+    async def capture_note(_method: str, params: dict[str, Any]) -> None:
+        notes.append(params)
+
+    bus.on(Method.CHAT_WORK_NOTE, capture_note)
+    try:
+        await coordinator._on_provider_event(
+            Method.PROVIDER_EVENT,
+            _event("run-first-provider-direction", "run.created"),
+        )
+        await coordinator._on_provider_event(
+            Method.PROVIDER_EVENT,
+            _event(
+                "run-first-provider-direction",
+                "assistant.update",
+                {
+                    "text": "Mapping the two-player controls before implementation.",
+                    "source": "provider_tool_title",
+                },
+            ),
+        )
+    finally:
+        bus.off(Method.CHAT_WORK_NOTE, capture_note)
+
+    directional = [
+        note
+        for note in notes
+        if note.get("metadata", {}).get("narration_keypoint")
+        == "directional_progress"
+    ]
+    assert len(directional) == 1
+    assert directional[0]["summary"] == (
+        "Mapping the two-player controls before implementation."
+    )
+    assert directional[0]["metadata"]["semantic_candidate"] is True
+    print("ok: the first Provider-authored direction remains narratable")
 
 
 async def test_artifact_canvases_share_the_clamp() -> None:
@@ -225,7 +266,8 @@ async def test_heartbeat_names_the_run_provider_instead_of_a_legacy_default() ->
 async def main() -> None:
     await test_live_event_progress_never_moves_backwards()
     await test_new_run_id_resets_the_clamp()
-    await test_run_intake_exposes_the_host_dispatched_goal_as_direction()
+    await test_run_intake_stays_on_the_work_surface_without_narration()
+    await test_first_provider_direction_after_intake_remains_narratable()
     await test_artifact_canvases_share_the_clamp()
     await test_semantic_lead_survives_status_and_heartbeat_refreshes()
     await test_heartbeat_names_the_run_provider_instead_of_a_legacy_default()

--- a/tests/test_work_semantic_progress.py
+++ b/tests/test_work_semantic_progress.py
@@ -40,9 +40,23 @@ def test_validation_commands_are_facts_but_ordinary_commands_are_not() -> None:
             "command": "python -m pytest tests/test_game.py",
         },
     )
+    failed = semantic_progress_fact(
+        "tool.result",
+        {
+            "item_id": "test-2",
+            "success": False,
+            "status": "completed",
+        },
+        tool_context={
+            "tool": "command_execution",
+            "item_id": "test-2",
+            "command": "python -m pytest tests/test_game.py",
+        },
+    )
     assert ordinary is None
     assert started is not None and started.summary == "Project validation started."
     assert finished is not None and finished.summary == "Project validation passed."
+    assert failed is not None and failed.summary.startswith("Project validation failed")
     assert started.verified is True and finished.verified is True
 
 
@@ -55,6 +69,24 @@ def test_untyped_assistant_update_is_candidate_evidence_only() -> None:
     assert candidate.evidence == "candidate"
     assert candidate.verified is False
     assert candidate.milestone == ""
+
+
+def test_unstructured_dynamic_tool_output_never_becomes_a_progress_fact() -> None:
+    result = semantic_progress_fact(
+        "tool.result",
+        {
+            "name": "js",
+            "item_id": "dynamic-1",
+            "success": True,
+            "status": "completed",
+            "output": "pvz.html updated; syntax: pass; missing: []",
+        },
+        tool_context={
+            "tool": "js",
+            "item_id": "dynamic-1",
+        },
+    )
+    assert result is None
 
 
 def test_file_results_use_correlated_context_for_both_provider_shapes() -> None:
@@ -191,12 +223,63 @@ def test_verified_fact_reaches_provider_neutral_work_note() -> None:
     asyncio.run(run())
 
 
+def test_reported_milestone_note_retains_its_evidence_strength() -> None:
+    async def run() -> None:
+        notes: list[dict] = []
+
+        async def capture(_method: str, params: dict) -> None:
+            notes.append(params)
+
+        coordinator = WorkActivityCoordinator()
+        bus.on(Method.CHAT_WORK_NOTE, capture)
+        try:
+            await coordinator._on_provider_event(
+                Method.PROVIDER_EVENT,
+                {
+                    "provider": "contract-test",
+                    "run_id": "reported-design-run",
+                    "task": "Build the game",
+                    "metadata": {"session_id": "semantic-session"},
+                    "type": "semantic.progress",
+                    "payload": {
+                        "milestone": "design",
+                        "summary": "I will map the controls before implementing them.",
+                        "source": "provider_explicit_progress",
+                        "verified": False,
+                    },
+                },
+            )
+        finally:
+            bus.off(Method.CHAT_WORK_NOTE, capture)
+            await coordinator._leave_work("reported-design-run", reason="test")
+
+        semantic = [
+            note
+            for note in notes
+            if note.get("metadata", {}).get("narration_keypoint")
+            == "semantic_progress"
+        ]
+        assert len(semantic) == 1
+        metadata = semantic[0]["metadata"]
+        assert metadata["semantic_verified"] is False
+        assert metadata["semantic_evidence"] == "reported"
+        assert metadata["semantic_source"] == "provider_explicit_progress"
+        report = next(
+            signal for signal in semantic[0]["signals"] if signal.get("label") == "report"
+        )
+        assert "not verified" in report["detail"]
+
+    asyncio.run(run())
+
+
 def main() -> None:
     test_validation_commands_are_facts_but_ordinary_commands_are_not()
     test_untyped_assistant_update_is_candidate_evidence_only()
+    test_unstructured_dynamic_tool_output_never_becomes_a_progress_fact()
     test_file_results_use_correlated_context_for_both_provider_shapes()
     test_permission_and_artifact_projection_stays_truthful_and_bounded()
     test_verified_fact_reaches_provider_neutral_work_note()
+    test_reported_milestone_note_retains_its_evidence_strength()
     print("ok: canonical provider events project into bounded semantic progress facts")
 
 


### PR DESCRIPTION
## 中文摘要

> 给中文审阅者的速览；下方英文正文仍是完整技术说明。

- **问题**：中途 amend 后，状态查询可能继续选用修改前的 design，丢失 verified=false，并让 Narrator 把未来计划说成已实现或已验证结果；同时 run intake 会抢占首条语义播报，旧的待播非终态内容也不会随 steer 失效。
- **修复**：复用现有 steering revision/observedAt 与 milestone observedAt/verified/source 形成当前证据边界。queued/applied steer 后不再把旧计划当作当前进展；rejected steer 仍保留原事实；过期待播内容被清理，但 terminal truth 不受影响。
- **工具边界**：Codex 原生工具的结构化标题只进入“未验证方向”通道；任意 js/dynamic-tool 输出文本仍不能被解析成文件、能力、验证或完成事实。success=false 也不会再因为 status=completed 被升级为成功。
- **实现范围**：run.created 只更新 Work 界面，不消耗首条实质语音机会。没有新增 schema、模型调用、兼容 fallback、工具名白名单或输出关键词规则。
- **验证**：公开完整 Python 基线 1682 项通过、1 项跳过；定向状态查询、steer、Observer、Codex adapter 与语义投影测试通过；Ruff、compileall、diff 检查及公开 Electron/Python CI 均通过。尚未补做新的真实 Kurisu+TTS 长作业验收。

关联问题：#24。

## What and why

Work narration could keep a pre-amend design as the latest status evidence, discard its verification strength, and present future intent to the Narrator as verified progress. The same run could spend its first spoken update repeating the Host-dispatched task, while queued pre-steer narration remained eligible after the instruction changed.

This PR repairs the complete current-evidence boundary:

- run intake remains visible on the Work surface without becoming semantic narration;
- queued/applied steer checkpoints fence status evidence by the existing observed timestamps;
- rejected steer keeps the prior fact current;
- milestone source, verification, and evidence strength reach status and narration;
- queued nonterminal narration from the superseded instruction is retired while terminal truth remains protected;
- Codex native tool fields are normalized at the adapter boundary;
- a structured native tool title becomes only an unverified direction;
- arbitrary dynamic-tool output remains fail-closed;
- explicit success=false cannot be upgraded by status=completed.

Fixes #24

## Product semantics

This is a bounded Work presentation and evidence-authority repair.

The Host continues to own Work identity, steering state, activity facts, verification, cadence, and delivery. Provider prose and native tool titles remain reported evidence, never completion or Host verification. Existing durable milestones remain in history; only their use as current status evidence is fenced after steer.

The implementation reuses activity steering revision/observedAt, milestone observedAt/verified/source, and the existing narration supersession path. It does not add a schema, model pass, tool-output parser, compatibility fallback, or js-specific exception.

## Change class

- [ ] Routine fix, documentation, test, maintenance, or presentation-only UI
- [x] Product-semantic or public-contract change discussed in the linked Issue
- [ ] Isolated, default-off experiment

Owning layers: Codex canonical event adapter, Host Work activity/status projection, and Work Observer cadence/delivery.

User-visible effect: after an amendment, Kurisu no longer reports the superseded design as current verified progress; intake does not consume the first substantive spoken update; structured current direction can still be narrated without being upgraded to a result.

Compatibility or migration impact: none. No database, persisted-state, public configuration, Provider capability, protocol, or API migration.

## Evidence

Focused public-baseline checks:

- Work narration, semantic progress, Codex adapter, activity snapshot, governor, recovery, quiet narration, and role sanitization: 90 passed.
- Task lookup: 24 passed.
- Runtime control authority: 14 passed.
- Workflow progress direct regression checks passed.

Full public Python baseline:

- python -X utf8 tools/run_tests.py
- 1682 passed, 1 skipped.

Static checks:

- Ruff on all changed Python files passed.
- compileall on all changed Python files passed.
- git diff --check passed.

No Electron files, dependencies, settings, schema, or UI layout changed. No paid live-model or new real TTS journey was used; deterministic event-chain and full-suite evidence cover this PR, while a post-merge live narration journey remains useful acceptance evidence.

- [x] Relevant Python tests pass
- [x] CPU/model-less baseline remains supported
- [ ] Electron npm run build passes (not applicable; no Electron change)
- [ ] Dependency audit passes (not applicable; no dependency change)
- [ ] Before/after screenshots are attached (not applicable; no UI layout change)
- [ ] Documentation/examples are updated (not applicable; existing authority contract is restored without changing settings or public schema)

## Final check

- [x] This PR addresses one coherent Work narration truth problem
- [x] It reuses existing authority and freshness facts instead of adding parallel state
- [x] Unknown dynamic-tool output remains fail-closed
- [x] It does not add a speculative API, fallback, model pass, or provider-output keyword parser
- [x] No secrets, local state, model weights, voice material, restricted assets, runtime logs, or personal paths are included
- [x] Third-party notices and provenance are preserved
