### PR TITLE
fix(auip): bind pending preparation to active work

### DIFF
--- a/core/chat_runtime.py
+++ b/core/chat_runtime.py
@@ -2488,6 +2488,37 @@ class ChatRuntime:
                 work_item_id = str(
                     getattr(decision, "preparation_work_item_id", "") or ""
                 ).strip()
+                active_attempt_ids = tuple(
+                    getattr(decision, "active_work_attempt_ids", ()) or ()
+                )
+                if (
+                    active_attempt_ids
+                    and str(getattr(decision, "work_relation", "") or "")
+                    == "subsumed"
+                ):
+                    # A pure request to join the one unfinished deliverable is
+                    # fulfilled by Host-grounded AUIP preparation of that
+                    # existing WorkItem.  A role/canonical execute proposal for
+                    # the same transition is duplicate Work, not the owner of
+                    # a second WorkItem.
+                    duplicate_starts = list(starts_work)
+                    actions = [
+                        action
+                        for action in actions
+                        if action not in duplicate_starts
+                    ]
+                    starts_work = [
+                        action
+                        for action in actions
+                        if self._delegate_action_starts_work(action)
+                    ]
+                    logger.info(
+                        "[AUIP-CONTROL] suppressed duplicate Work proposal for "
+                        "active preparation turn_id=%s attempts=%d count=%d",
+                        st.turn_id,
+                        len(active_attempt_ids),
+                        len(duplicate_starts),
+                    )
                 # Cross-axis reconciliation may collapse several competing
                 # Work starts to the one source-local preparation prerequisite,
                 # but it must not turn zero authority-approved starts into one.

--- a/server/auip_control_decision.py
+++ b/server/auip_control_decision.py
@@ -173,6 +173,14 @@ class AuipControlDecision:
                 attrs["_host_preparation_work_item_id"] = (
                     self.preparation_work_item_id
                 )
+            if self.active_work_attempt_ids:
+                # Host-captured identity for an unfinished deliverable that
+                # the user explicitly asked to prepare for participation.  The
+                # launch coordinator revalidates these Attempts against the
+                # current Session roster before it starts ordinary amend Work.
+                attrs["_host_active_work_attempt_ids"] = tuple(
+                    self.active_work_attempt_ids
+                )
             return attrs
         attrs = {"action": self.action}
         if self.action == "step":
@@ -563,6 +571,13 @@ open. Do not choose launch versus prepare. Questions, discussion, status or
 strategy queries, future wishes, and app feature authoring without a request
 to enter the experience are `none`.
 
+When `other_provider_work_active` is true and the current turn explicitly asks
+to connect to, join, or play the one pending deliverable discussed in history,
+return immediate `engage` with `work_relation=subsumed`. Host code may compile
+that request into preparation of the still-running WorkItem. Do not use this
+for an unrelated Work clause or infer application entry from work activity
+alone.
+
 Opening an unrelated web page is not AUIP. Use `after_work` only when the exact
 turn asks to enter after create/amend Work completes.
 
@@ -759,6 +774,7 @@ class AuipControlDecisionResolver:
                 decision,
                 candidates=candidates,
                 preparation_candidates=preparation_candidates,
+                active_work_attempt_ids=active_work_attempt_ids,
             )
         if decision.status == "ok" and decision.action == "prepare":
             target = decision.target.casefold()
@@ -839,8 +855,29 @@ def _compile_entry_decision(
     *,
     candidates: tuple[Any, ...],
     preparation_candidates: tuple[Any, ...],
+    active_work_attempt_ids: tuple[str, ...] = (),
 ) -> AuipControlDecision:
     """Resolve one requested experience against frozen Host capability facts."""
+
+    if (
+        decision.timing == "now"
+        and decision.work_relation == "subsumed"
+        and active_work_attempt_ids
+        and not candidates
+        and not preparation_candidates
+    ):
+        # The requested application is still being authored, so there is no
+        # Artifact identity to place in the ordinary preparation catalog yet.
+        # Preserve only frozen Attempt identity here; the launch coordinator
+        # must rejoin it to exactly one current Session WorkItem before amend.
+        return AuipControlDecision(
+            status="ok",
+            action="prepare",
+            mode=decision.mode,
+            active_work_attempt_ids=tuple(active_work_attempt_ids),
+            work_relation="subsumed",
+            raw_reply=decision.raw_reply,
+        )
 
     if decision.timing == "after_work" and preparation_candidates and not candidates:
         # "Connect/adapt it, then open it" still names the already-existing
@@ -1060,7 +1097,12 @@ def parse_auip_control_decision(
                 timing == "now"
                 and work_relation not in {"subsumed", "independent"}
             )
-            or (timing == "now" and not has_active and not available_titles)
+            or (
+                timing == "now"
+                and not has_active
+                and not available_titles
+                and not has_active_work
+            )
         ):
             return AuipControlDecision(
                 status="invalid",

--- a/server/auip_launch.py
+++ b/server/auip_launch.py
@@ -84,7 +84,11 @@ class AuipLaunchCandidate:
 
 @dataclass(frozen=True, slots=True)
 class AuipPreparationCandidate:
-    """Host-verified runnable Work that needs AUIP before it can launch."""
+    """Host-grounded Work that needs AUIP before it can launch.
+
+    ``files`` is populated for a verified runnable delivery and remains empty
+    while the same WorkItem is still producing its first Artifact.
+    """
 
     work_item_id: str
     work_title: str
@@ -410,11 +414,53 @@ class AuipLaunchCoordinator:
         turn_id: str,
         prepare_work: PreparationDispatcher | None,
     ) -> dict[str, Any]:
-        """Resolve one generic runnable delivery before starting ordinary Work."""
+        """Resolve one runnable or uniquely active Work before ordinary amend."""
 
         if prepare_work is None:
             await self._announce_failure(session_id, "preparation_unavailable")
             return {"ok": False, "error": "preparation_unavailable"}
+        active_attempt_ids = tuple(
+            dict.fromkeys(
+                str(value).strip()
+                for value in (attrs.get("_host_active_work_attempt_ids") or ())
+                if str(value).strip()
+            )
+        )
+        if active_attempt_ids:
+            rows = self._active_work_rows(session_id, active_attempt_ids)
+            candidates = [
+                AuipPreparationCandidate(
+                    work_item_id=str(row.get("work_item_id") or ""),
+                    work_title=str(row.get("title") or "WorkItem"),
+                    files=(),
+                )
+                for row in rows
+                if str(row.get("work_item_id") or "").strip()
+            ]
+            candidates = list(
+                {
+                    candidate.work_item_id: candidate
+                    for candidate in candidates
+                }.values()
+            )
+            if len(candidates) == 1:
+                return await self._begin_preparation(
+                    session_id,
+                    turn_id,
+                    candidates[0],
+                    _mode(attrs.get("mode")),
+                    prepare_work,
+                )
+            if len(candidates) > 1:
+                return await self._request_preparation_selection(
+                    session_id,
+                    turn_id,
+                    candidates,
+                    _mode(attrs.get("mode")),
+                    prepare_work,
+                )
+            await self._announce_failure(session_id, "deferred_work_unavailable")
+            return {"ok": False, "error": "deferred_work_unavailable"}
         candidates = self.preparation_candidates(session_id)
         frozen_work_item_id = str(
             attrs.get("_host_preparation_work_item_id") or ""

--- a/tests/test_auip_control_decision.py
+++ b/tests/test_auip_control_decision.py
@@ -600,6 +600,90 @@ def test_active_work_is_exposed_only_as_a_bounded_ambiguity_fact() -> None:
     ).status == "invalid"
 
 
+def test_pending_work_entry_compiles_to_host_grounded_preparation() -> None:
+    async def scenario() -> None:
+        captured: list[dict[str, str]] = []
+
+        async def query(messages):
+            captured.extend(messages)
+            return json.dumps(
+                {
+                    "action": "engage",
+                    "timing": "now",
+                    "mode": "collaborate",
+                    "target": "",
+                    "work_relation": "subsumed",
+                }
+            )
+
+        resolver = AuipControlDecisionResolver(
+            query=query,
+            app_runtime=_Runtime(),
+            launch_catalog=_Catalog(),
+            has_active_work=lambda _session_id: ("attempt-private",),
+        )
+        pending = resolver.capture(
+            session_id="s",
+            user_text="你能接入他吗？我想和你一起玩",
+            prior_messages=[
+                {"role": "user", "content": "帮我做一个双人游戏。"},
+                {"role": "assistant", "content": "还在制作。"},
+            ],
+            include_work_followup=True,
+        )
+        assert pending is not None
+        decision = await pending
+
+        assert decision.status == "ok"
+        assert decision.action == "prepare"
+        assert decision.mode == "collaborate"
+        assert decision.work_relation == "subsumed"
+        assert decision.active_work_attempt_ids == ("attempt-private",)
+        assert decision.control_attrs() == {
+            "action": "prepare",
+            "mode": "collaborate",
+            "_host_active_work_attempt_ids": ("attempt-private",),
+        }
+        wire = json.dumps(captured, ensure_ascii=False)
+        assert "other_provider_work_active" in wire
+        assert "attempt-private" not in wire
+
+    asyncio.run(scenario())
+
+
+def test_pending_work_does_not_absorb_an_independent_work_clause() -> None:
+    async def scenario() -> None:
+        async def query(_messages):
+            return json.dumps(
+                {
+                    "action": "engage",
+                    "timing": "now",
+                    "mode": "collaborate",
+                    "target": "",
+                    "work_relation": "independent",
+                }
+            )
+
+        resolver = AuipControlDecisionResolver(
+            query=query,
+            app_runtime=_Runtime(),
+            launch_catalog=_Catalog(),
+            has_active_work=lambda _session_id: ("attempt-private",),
+        )
+        pending = resolver.capture(
+            session_id="s",
+            user_text="游戏继续做，另外帮我查一下明天的天气。",
+            include_work_followup=True,
+        )
+        assert pending is not None
+        decision = await pending
+
+        assert decision.status == "invalid"
+        assert decision.control_attrs() is None
+
+    asyncio.run(scenario())
+
+
 def test_resolver_exposes_only_the_current_lifecycle_vocabulary() -> None:
     async def scenario() -> None:
         active_messages = []
@@ -1950,6 +2034,81 @@ def test_preparation_fills_only_a_missing_bounded_work_proposal() -> None:
                 "mode": "collaborate",
                 "target": "井字棋",
                 "_host_preparation_work_item_id": "work-existing-game",
+            }
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_active_preparation_suppresses_a_duplicate_new_work_proposal() -> None:
+    async def scenario() -> None:
+        routed: list[dict] = []
+
+        async def route(attrs, **_context):
+            routed.append(dict(attrs))
+
+        async def decide(_messages):
+            return json.dumps(
+                {
+                    "action": "engage",
+                    "timing": "now",
+                    "mode": "collaborate",
+                    "target": "",
+                    "work_relation": "subsumed",
+                }
+            )
+
+        role_work = {
+            "provider": "codex",
+            "intent": "execute",
+            "subject": "project",
+            "project_id": "project-wrong",
+            "task": "你能接入他吗？我想和你一起玩",
+        }
+        runtime = ChatRuntime()
+        runtime.configure(
+            control_proposal_observer=_AuthorityObserver(
+                outcome="agree",
+                actions=(role_work,),
+            ),
+            control_proposal_authority=True,
+            auip_control_callback=route,
+            auip_control_decider=AuipControlDecisionResolver(
+                query=decide,
+                app_runtime=_Runtime(),
+                launch_catalog=_Catalog(),
+                has_active_work=lambda _session_id: ("attempt-active",),
+            ),
+        )
+        state = _state(
+            "turn-prepare-active-work",
+            question="你能接入他吗？我想和你一起玩",
+        )
+        with (
+            patch("core.chat_runtime.record_actions") as record,
+            patch.object(
+                provider_runtime,
+                "provider_manifests",
+                return_value=(CODEX_APP_SERVER_MANIFEST,),
+            ),
+        ):
+            runtime._consume_stream_chunk(
+                state,
+                '[DELEGATE provider="codex" intent="execute" subject="project" '
+                'project_id="project-wrong" task="你能接入他吗？我想和你一起玩"]',
+            )
+            await runtime._wait_for_control_authority(state)
+            await runtime._wait_for_auip_controls(state)
+
+        record.assert_not_called()
+        assert state.work_delegate_seen is False
+        assert state.control_effective_actions == []
+        assert "[DELEGATE" not in state.history_response
+        assert routed == [
+            {
+                "action": "prepare",
+                "mode": "collaborate",
+                "_host_active_work_attempt_ids": ("attempt-active",),
             }
         ]
 

--- a/tests/test_auip_launch.py
+++ b/tests/test_auip_launch.py
@@ -475,6 +475,66 @@ def test_preparation_targets_the_existing_generic_work_and_reserves_launch() -> 
     asyncio.run(scenario())
 
 
+def test_active_unfinished_work_is_prepared_without_creating_a_second_work_item() -> None:
+    async def scenario() -> None:
+        with tempfile.TemporaryDirectory(prefix="auip_launch_prepare_active_") as temp:
+            root = Path(temp)
+            store = WorkLedgerStore(root / "ledger.sqlite3")
+            project = store.create_or_get_project(root / "project")
+            item = store.create_work_item(
+                project.project_id,
+                title="Two-player Garden Duel",
+                workspace_path=root / "game",
+            )
+            _operation, attempt = store.create_operation_attempt(
+                item.work_item_id,
+                intent="execute",
+                instruction="Build the two-player game",
+                provider="codex",
+                task="Build the two-player game",
+                attempt_metadata={"session_id": SESSION, "turn_id": "turn-build"},
+            )
+            store.update_attempt(attempt.attempt_id, execution_status="running")
+            prepared: list[tuple[str, str, tuple[str, ...]]] = []
+
+            async def prepare_work(candidate, mode):
+                prepared.append((candidate.work_item_id, mode, candidate.files))
+
+            coordinator = AuipLaunchCoordinator(
+                artifacts=store,
+                work_roster=WorkLedgerCoordinator(store),
+                attention=AttentionRequestCoordinator(),
+            )
+            result = await coordinator.route_control(
+                {
+                    "action": "prepare",
+                    "mode": "collaborate",
+                    "_host_active_work_attempt_ids": (attempt.attempt_id,),
+                },
+                session_id=SESSION,
+                turn_id="turn-play-together",
+                prepare_work=prepare_work,
+            )
+
+            assert result == {
+                "ok": True,
+                "deferred": True,
+                "preparing": True,
+                "turn_id": "turn-play-together",
+            }
+            pending = coordinator._deferred[(SESSION, "turn-play-together")]
+            project_work_count = sum(
+                record.project_id == project.project_id
+                for record in store.list_work_items()
+            )
+            store.close()
+            assert prepared == [(item.work_item_id, "collaborate", ())]
+            assert project_work_count == 1
+            assert pending.work_item_id == item.work_item_id
+
+    asyncio.run(scenario())
+
+
 def test_failed_preparation_uses_the_work_terminal_without_a_second_launch_report() -> None:
     async def scenario() -> None:
         with tempfile.TemporaryDirectory(prefix="auip_launch_prepare_failure_") as temp:


### PR DESCRIPTION
## Summary

- compile an explicit request to join a still-running deliverable into Host-grounded AUIP preparation
- suppress a duplicate Work start while preserving independent Work clauses
- revalidate frozen active Attempt identity against the current Session roster and reserve launch on the original WorkItem

## Regression coverage

- reproduces `你能接入他吗？我想和你一起玩` while the game WorkItem is still running and has no Artifact
- verifies an erroneous `execute project` proposal cannot create a second WorkItem
- verifies unrelated independent Work is not absorbed
- verifies the preparation callback receives the original WorkItem and keeps the Ledger at one WorkItem

## Validation

- `python -m ruff check core/chat_runtime.py server/auip_control_decision.py server/auip_launch.py tests/test_auip_control_decision.py tests/test_auip_launch.py`
- `101 passed` — AUIP control, launch, action-existence, and delegate dispatch
- `55 passed` — cross-axis assembly, runtime control, amend intent, WorkItem continuity, and export