### PR TITLE
feat(chat): add render-only translation subtitles

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -6,7 +6,7 @@
   "main": "dist/main/index.js",
   "scripts": {
     "postinstall": "install-electron",
-    "test": "node --experimental-strip-types --test tests/providerEventVisibility.test.mjs",
+    "test": "node --experimental-strip-types --test tests/*.test.mjs",
     "dev": "vite",
     "build": "tsc && vite build",
     "electron:dev": "concurrently \"vite\" \"wait-on http://localhost:5173 && electron .\"",

--- a/electron/src/renderer/components/ChatBubble.tsx
+++ b/electron/src/renderer/components/ChatBubble.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown'
 interface Props {
   role: 'user' | 'assistant' | 'system'
   text: string
+  translation?: string
   streaming?: boolean
   onStreamIdle?: () => void
   userAvatar?: string
@@ -12,7 +13,7 @@ interface Props {
 
 const DOT_PHASES = ['●', '● ●', '● ● ●', '● ●']
 
-export default function ChatBubble({ role, text, streaming, onStreamIdle, userAvatar = '', assistantAvatar = '' }: Props) {
+export default function ChatBubble({ role, text, translation = '', streaming, onStreamIdle, userAvatar = '', assistantAvatar = '' }: Props) {
   const [display, setDisplay] = useState(text)
   const [dotPhase, setDotPhase] = useState(0)
   const [cursorVisible, setCursorVisible] = useState(true)
@@ -116,6 +117,22 @@ export default function ChatBubble({ role, text, streaming, onStreamIdle, userAv
           }}
         >
           {isUser ? display : <ReactMarkdown className="markdown-body">{display}</ReactMarkdown>}
+          {!isUser && translation ? (
+            <div
+              aria-label="Simplified Chinese translation"
+              className="whitespace-pre-wrap break-words"
+              style={{
+                borderTop: '1px solid var(--border)',
+                color: 'var(--muted)',
+                fontSize: 11.5,
+                lineHeight: '155%',
+                marginTop: 7,
+                paddingTop: 7,
+              }}
+            >
+              {translation}
+            </div>
+          ) : null}
         </div>
       </div>
 

--- a/electron/src/renderer/components/ChatPage.tsx
+++ b/electron/src/renderer/components/ChatPage.tsx
@@ -24,6 +24,10 @@ import {
   patchInterruptedMessage,
   type Message,
 } from './chatMessageState'
+import {
+  chatTranslationCandidates,
+  chatTranslationKey,
+} from './chatTranslationState'
 
 interface Props {
   send: (method: string, params?: Record<string, unknown>) => Promise<Record<string, unknown>>
@@ -164,6 +168,8 @@ async function prepareImageAttachment(file: File): Promise<VisualAttachment> {
 
 export default function ChatPage({ send, subscribe, connected, renderActive, renderAssetUrl }: Props) {
   const [messages, setMessages] = useState<Message[]>([])
+  const [chatTranslationEnabled, setChatTranslationEnabled] = useState(false)
+  const [chatTranslations, setChatTranslations] = useState<Record<string, string>>({})
   const [workActivities, setWorkActivities] = useState<ChatWorkActivityRun[]>([])
   const [streamingText, setStreamingText] = useState('')
   const [streaming, setStreaming] = useState(false)
@@ -208,6 +214,8 @@ export default function ChatPage({ send, subscribe, connected, renderActive, ren
   const activeStreamTurnIdRef = useRef('')
   const streamingTextRef = useRef('')
   const lastAssistantTurnIdRef = useRef('')
+  const chatTranslationRequestedRef = useRef<Set<string>>(new Set())
+  const chatTranslationGenerationRef = useRef(0)
   const activeSessionRef = useRef('')
   const visionPressTimerRef = useRef<number | null>(null)
   const visionLongPressRef = useRef(false)
@@ -262,7 +270,12 @@ export default function ChatPage({ send, subscribe, connected, renderActive, ren
       activeSessionRef.current = sessionId
       setActiveSession(sessionId)
     }
-    if (Array.isArray(res.messages)) setMessages(toMessages(res.messages))
+    if (Array.isArray(res.messages)) {
+      chatTranslationGenerationRef.current += 1
+      chatTranslationRequestedRef.current.clear()
+      setChatTranslations({})
+      setMessages(toMessages(res.messages))
+    }
     setStreaming(false)
     setStreamingText('')
     streamingTextRef.current = ''
@@ -296,6 +309,57 @@ export default function ChatPage({ send, subscribe, connected, renderActive, ren
       if (value) setChatAvatars(value)
     }).catch(error => console.error('[chat-avatar] load failed', error))
   }, [])
+
+  useEffect(() => {
+    if (!connected) return
+    let cancelled = false
+    const applyConfig = (payload: Record<string, unknown>) => {
+      const values = payload.values && typeof payload.values === 'object'
+        ? payload.values as Record<string, unknown>
+        : payload
+      const enabled = values.chat_translation_subtitles_enabled === true
+      if (!cancelled) setChatTranslationEnabled(enabled)
+    }
+    const unsubscribe = subscribe('system.config', applyConfig)
+    send('system.get_config', {}).then(applyConfig).catch(() => {
+      if (!cancelled) setChatTranslationEnabled(false)
+    })
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [connected, send, subscribe])
+
+  useEffect(() => {
+    if (!chatTranslationEnabled) {
+      chatTranslationGenerationRef.current += 1
+      chatTranslationRequestedRef.current.clear()
+      setChatTranslations({})
+      return
+    }
+
+    const generation = chatTranslationGenerationRef.current
+    for (const candidate of chatTranslationCandidates(messages)) {
+      if (chatTranslationRequestedRef.current.has(candidate.key)) continue
+      chatTranslationRequestedRef.current.add(candidate.key)
+      void send('chat.translate', {
+        text: candidate.text,
+        turn_id: candidate.turnId,
+      }).then(response => {
+        if (generation !== chatTranslationGenerationRef.current) return
+        const translation = String(response.translation ?? '').trim()
+        if (!translation) return
+        setChatTranslations(previous => ({
+          ...previous,
+          [candidate.key]: translation,
+        }))
+      }).catch(() => {
+        if (generation === chatTranslationGenerationRef.current) {
+          chatTranslationRequestedRef.current.delete(candidate.key)
+        }
+      })
+    }
+  }, [chatTranslationEnabled, messages, send])
 
   // auto-scroll
   useEffect(() => {
@@ -1297,6 +1361,7 @@ export default function ChatPage({ send, subscribe, connected, renderActive, ren
                 <ChatBubble
                   role={msg.role}
                   text={msg.text}
+                  translation={chatTranslations[chatTranslationKey(msg, i)] || ''}
                   streaming={msg.streaming}
                   userAvatar={chatAvatars.user}
                   assistantAvatar={chatAvatars.assistant}

--- a/electron/src/renderer/components/SettingsPage.tsx
+++ b/electron/src/renderer/components/SettingsPage.tsx
@@ -694,6 +694,7 @@ export default function SettingsPage({ send, subscribe }: Props) {
                 </SettingsGroup>
                 <SettingsGroup title="Chat & Voice">
                   <ComboCard icon="Language" title="Slice Language" content="Language for process cards and Provider summaries" value={val('presentation_locale', 'en-US')} onChange={value => handleChange('presentation_locale', value)} options={['en-US', 'zh-CN', 'ja-JP']} />
+                  <SwitchCard icon="Language" title="Chat Translation Subtitles" content="Show Simplified Chinese below completed Japanese assistant messages. Display-only; never added to conversation history." checked={bool('chat_translation_subtitles_enabled')} onChange={value => handleChange('chat_translation_subtitles_enabled', value)} />
                   <ComboCard icon="Language" title="Wallpaper Caption Mode" content="Choose translated, source, bilingual, or no captions" value={val('wallpaper_caption_mode', 'translated')} onChange={value => handleChange('wallpaper_caption_mode', value)} options={['translated', 'source', 'bilingual', 'off']} />
                 </SettingsGroup>
               </div>

--- a/electron/src/renderer/components/chatTranslationState.ts
+++ b/electron/src/renderer/components/chatTranslationState.ts
@@ -1,0 +1,31 @@
+import type { Message } from './chatMessageState'
+
+export interface ChatTranslationCandidate {
+  key: string
+  text: string
+  turnId: string
+}
+
+function textFingerprint(text: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+export function chatTranslationKey(message: Message, index: number): string {
+  if (message.role !== 'assistant' || message.streaming || !message.text.trim()) return ''
+  const identity = message.turnId ? `turn:${message.turnId}` : `message:${index}`
+  return `${identity}:${message.text.length}:${textFingerprint(message.text)}`
+}
+
+export function chatTranslationCandidates(messages: Message[]): ChatTranslationCandidate[] {
+  return messages.flatMap((message, index) => {
+    const key = chatTranslationKey(message, index)
+    return key
+      ? [{ key, text: message.text, turnId: message.turnId || '' }]
+      : []
+  })
+}

--- a/electron/tests/chatTranslationState.test.mjs
+++ b/electron/tests/chatTranslationState.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  chatTranslationCandidates,
+  chatTranslationKey,
+} from '../src/renderer/components/chatTranslationState.ts'
+
+test('translation candidates contain only completed assistant display text', () => {
+  const messages = [
+    { role: 'user', text: '続けて' },
+    { role: 'assistant', text: '今から確認するわ。', turnId: 'turn-1', streaming: true },
+    { role: 'assistant', text: '確認が終わったわ。', turnId: 'turn-2', streaming: false },
+    { role: 'system', text: 'backend ready' },
+  ]
+
+  assert.deepEqual(chatTranslationCandidates(messages), [{
+    key: chatTranslationKey(messages[2], 2),
+    text: '確認が終わったわ。',
+    turnId: 'turn-2',
+  }])
+})
+
+test('translation identity changes with visible text without mutating history messages', () => {
+  const original = { role: 'assistant', text: '確認中よ。', turnId: 'turn-1', streaming: false }
+  const messages = [original]
+  const before = structuredClone(messages)
+  const firstKey = chatTranslationKey(original, 0)
+  const nextKey = chatTranslationKey({ ...original, text: '確認が終わったわ。' }, 0)
+
+  assert.notEqual(firstKey, nextKey)
+  assert.deepEqual(messages, before)
+  assert.equal('translation' in original, false)
+})

--- a/server/chat_translation_runtime.py
+++ b/server/chat_translation_runtime.py
@@ -1,0 +1,80 @@
+"""Render-only translated subtitles for completed GUI Chat messages.
+
+The source text remains the clean Main Chat response.  Translations are
+requested on demand by the trusted GUI and are never projected into
+conversation history, session storage, TTS, or Provider context.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from server.assistant_language import text_matches_assistant_language
+
+SETTING_KEY = "chat_translation_subtitles_enabled"
+MAX_SOURCE_CHARS = 16_000
+
+
+def _env_enabled(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+
+_enabled = _env_enabled("AMADEUS_CHAT_TRANSLATION_SUBTITLES_ENABLED", False)
+
+
+def is_enabled() -> bool:
+    return _enabled
+
+
+def get_config() -> dict[str, bool]:
+    return {SETTING_KEY: _enabled}
+
+
+def set_config(values: Mapping[str, object]) -> list[str]:
+    global _enabled
+    if SETTING_KEY not in values:
+        return []
+    enabled = values[SETTING_KEY]
+    if not isinstance(enabled, bool):
+        raise ValueError(f"{SETTING_KEY} must be a boolean")
+    if enabled == _enabled:
+        return []
+    _enabled = enabled
+    return [SETTING_KEY]
+
+
+def _looks_like_japanese_source(text: str) -> bool:
+    # Use the existing presentation-language contract instead of guessing
+    # that an all-Han line is Japanese; that avoids retranslating a Chinese
+    # Observer entry while Japanese remains the primary voice language.
+    return text_matches_assistant_language(text, "japanese")
+
+
+async def translate_completed_message(value: object) -> dict[str, Any]:
+    """Translate one clean completed assistant message for GUI display only."""
+
+    if not _enabled:
+        return {"status": "disabled", "translation": ""}
+
+    text = str(value or "").strip()
+    if not text:
+        return {"status": "empty", "translation": ""}
+    if len(text) > MAX_SOURCE_CHARS:
+        raise ValueError(f"chat translation source exceeds {MAX_SOURCE_CHARS} characters")
+    if not _looks_like_japanese_source(text):
+        return {"status": "not_japanese", "translation": ""}
+
+    from server.wallpaper_subtitle_translator import (
+        translate_presentation_subtitle,
+    )
+
+    translation = await translate_presentation_subtitle(text)
+    return {
+        "status": "translated" if translation else "unavailable",
+        "translation": str(translation or ""),
+    }

--- a/server/handlers/chat_handler.py
+++ b/server/handlers/chat_handler.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class ChatHandler(RequestHandler):
-    methods = [Method.CHAT_SEND, Method.CHAT_ABORT]
+    methods = [Method.CHAT_SEND, Method.CHAT_ABORT, Method.CHAT_TRANSLATE]
 
     def __init__(self) -> None:
         self._stream_task: asyncio.Task | None = None
@@ -60,7 +60,19 @@ class ChatHandler(RequestHandler):
             return await self._handle_send(params)
         if method == Method.CHAT_ABORT:
             return await self._handle_abort(params)
+        if method == Method.CHAT_TRANSLATE:
+            return await self._handle_translate(params)
         return None
+
+    @staticmethod
+    async def _handle_translate(params: dict[str, Any]) -> dict[str, Any]:
+        """Return a derived GUI subtitle without touching Chat history."""
+
+        from server.chat_translation_runtime import translate_completed_message
+
+        result = await translate_completed_message(params.get("text", ""))
+        result["turn_id"] = str(params.get("turn_id") or "")
+        return result
 
     async def send_text(
         self,

--- a/server/handlers/system_handler.py
+++ b/server/handlers/system_handler.py
@@ -833,6 +833,7 @@ class SystemHandler(RequestHandler):
         import llm.client as llm_client
         from server import visual_runtime
         from server import presentation_runtime
+        from server import chat_translation_runtime
         from render.character_pack import character_pack_status
         from config.asset_packages import external_asset_pack_status
         import tts.pipeline as tts_pipeline
@@ -896,6 +897,7 @@ class SystemHandler(RequestHandler):
             "vision_region": vision.get("region", ""),
             "vision_window_handle": vision.get("window_handle", ""),
             **presentation_runtime.get_config(),
+            **chat_translation_runtime.get_config(),
             "control_decision_mode": (
                 "authority"
                 if bool(getattr(chat_runtime, "_control_proposal_authority", False))
@@ -911,6 +913,7 @@ class SystemHandler(RequestHandler):
             raise ValueError("system.set_config requires a non-empty values object")
 
         from server import presentation_runtime
+        from server import chat_translation_runtime
         from server import visual_runtime
         from server import wallpaper_subtitle_runtime
         import tts.pipeline as tts_pipeline
@@ -932,6 +935,7 @@ class SystemHandler(RequestHandler):
             "presentation_locale",
             "wallpaper_caption_mode",
             "wallpaper_subtitle_language",
+            "chat_translation_subtitles_enabled",
         }
         unknown = sorted(str(key) for key in values if str(key) not in allowed)
         if unknown:
@@ -1003,6 +1007,11 @@ class SystemHandler(RequestHandler):
             if caption_mode not in presentation_runtime.VALID_CAPTION_MODES:
                 raise ValueError(f"unsupported wallpaper caption mode: {caption_mode!r}")
             values["wallpaper_caption_mode"] = caption_mode
+        if (
+            "chat_translation_subtitles_enabled" in values
+            and not isinstance(values["chat_translation_subtitles_enabled"], bool)
+        ):
+            raise ValueError("chat_translation_subtitles_enabled must be a boolean")
 
         if {"llm_provider", "local_llm_type"}.intersection(values):
             if self._is_chat_busy is not None and self._is_chat_busy():
@@ -1060,9 +1069,15 @@ class SystemHandler(RequestHandler):
 
         visual_updated = visual_runtime.set_config(values)
         presentation_updated = presentation_runtime.set_config(values)
+        chat_translation_updated = chat_translation_runtime.set_config(values)
         if presentation_updated:
             wallpaper_subtitle_runtime.refresh()
-        updated = list(dict.fromkeys([*updated, *visual_updated, *presentation_updated]))
+        updated = list(dict.fromkeys([
+            *updated,
+            *visual_updated,
+            *presentation_updated,
+            *chat_translation_updated,
+        ]))
         current = await self._get_config({})
         await bus.emit(Method.SYSTEM_CONFIG, {"values": current, "updated": updated})
         return {"updated": updated, "values": current}

--- a/server/protocol.py
+++ b/server/protocol.py
@@ -40,6 +40,7 @@ class Method(StrEnum):
     # Chat
     CHAT_SEND          = "chat.send"
     CHAT_ABORT         = "chat.abort"
+    CHAT_TRANSLATE     = "chat.translate"
     CHAT_TOKEN         = "chat.token"
     CHAT_COMPLETE      = "chat.complete"
     CHAT_ERROR         = "chat.error"
@@ -259,6 +260,10 @@ class ChatTokenParams(TypedDict):
 class ChatCompleteParams(TypedDict):
     turn_id: str
     full_text: str
+
+class ChatTranslateParams(TypedDict):
+    text: str
+    turn_id: NotRequired[str]
 
 class TtsSetModeParams(TypedDict):
     mode: str                # "gpt_sovits" | "edge" | ...

--- a/server/wallpaper_subtitle_translator.py
+++ b/server/wallpaper_subtitle_translator.py
@@ -1,7 +1,9 @@
-"""Provider-selectable Japanese -> Chinese translator for wallpaper subtitles.
+"""Provider-selectable Japanese -> Chinese presentation subtitle translator.
 
-This module is intentionally scoped to the Wallpaper/Lively subtitle surface.
-It does not affect chat memory, VN subtitle routing, or the text sent to TTS.
+Wallpaper/Lively and GUI Chat may share this provider configuration and output
+cleaning, but each surface owns its own enablement and render state.  This
+module never writes chat memory, changes VN subtitle routing, or alters TTS
+input.
 """
 
 from __future__ import annotations
@@ -49,7 +51,7 @@ def get_translation_runtime_info() -> dict[str, str | float | int]:
     }
 
 
-async def translate_wallpaper_subtitle(japanese_text: str) -> str:
+async def translate_presentation_subtitle(japanese_text: str) -> str:
     text = str(japanese_text or "").strip()
     if not text:
         return ""
@@ -67,7 +69,7 @@ async def translate_wallpaper_subtitle(japanese_text: str) -> str:
             if _looks_like_valid_translation(result):
                 elapsed_ms = int((asyncio.get_running_loop().time() - started) * 1000)
                 logger.info(
-                    "wallpaper subtitle translated provider=%s model=%s chars_in=%d chars_out=%d elapsed_ms=%d",
+                    "presentation subtitle translated provider=%s model=%s chars_in=%d chars_out=%d elapsed_ms=%d",
                     attempt.provider,
                     attempt.model,
                     len(text),
@@ -76,7 +78,7 @@ async def translate_wallpaper_subtitle(japanese_text: str) -> str:
                 )
                 return result
             logger.warning(
-                "wallpaper subtitle provider returned unusable text provider=%s model=%s chars_in=%d raw_len=%d",
+                "presentation subtitle provider returned unusable text provider=%s model=%s chars_in=%d raw_len=%d",
                 attempt.provider,
                 attempt.model,
                 len(text),
@@ -85,14 +87,20 @@ async def translate_wallpaper_subtitle(japanese_text: str) -> str:
         except Exception as exc:
             last_error = exc
             logger.warning(
-                "wallpaper subtitle translation attempt failed provider=%s: %s",
+                "presentation subtitle translation attempt failed provider=%s: %s",
                 provider,
                 exc,
             )
 
     if last_error is not None:
-        logger.error("wallpaper subtitle translation failed after fallbacks: %s", last_error)
+        logger.error("presentation subtitle translation failed after fallbacks: %s", last_error)
     return ""
+
+
+async def translate_wallpaper_subtitle(japanese_text: str) -> str:
+    """Compatibility entry point for the established Wallpaper pipeline."""
+
+    return await translate_presentation_subtitle(japanese_text)
 
 
 def _resolve_config() -> SubtitleTranslatorConfig:

--- a/tests/test_chat_translation_subtitle.py
+++ b/tests/test_chat_translation_subtitle.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.session_manager import conversation_history
+from server import chat_translation_runtime
+from server.handlers.chat_handler import ChatHandler
+from server.handlers.system_handler import SystemHandler
+from server.protocol import Method
+from server.wallpaper_subtitle_translator import _clean_translation
+
+
+def test_chat_translation_setting_is_independent_and_disabled_by_default() -> None:
+    original = chat_translation_runtime.is_enabled()
+    try:
+        chat_translation_runtime.set_config({"chat_translation_subtitles_enabled": False})
+        assert chat_translation_runtime.get_config() == {
+            "chat_translation_subtitles_enabled": False
+        }
+        assert chat_translation_runtime.set_config(
+            {"chat_translation_subtitles_enabled": True}
+        ) == ["chat_translation_subtitles_enabled"]
+        assert chat_translation_runtime.is_enabled() is True
+    finally:
+        chat_translation_runtime.set_config({"chat_translation_subtitles_enabled": original})
+
+
+def test_chat_translation_setting_rejects_non_boolean_values() -> None:
+    with pytest.raises(ValueError, match="must be a boolean"):
+        chat_translation_runtime.set_config({"chat_translation_subtitles_enabled": "true"})
+
+
+def test_disabled_or_non_japanese_chat_translation_never_calls_provider() -> None:
+    async def run() -> None:
+        original = chat_translation_runtime.is_enabled()
+        translate = AsyncMock(return_value="不应调用")
+        try:
+            chat_translation_runtime.set_config({"chat_translation_subtitles_enabled": False})
+            with patch(
+                "server.wallpaper_subtitle_translator.translate_presentation_subtitle",
+                new=translate,
+            ):
+                disabled = await chat_translation_runtime.translate_completed_message(
+                    "作業は終わったわ。"
+                )
+                chat_translation_runtime.set_config({"chat_translation_subtitles_enabled": True})
+                skipped = await chat_translation_runtime.translate_completed_message(
+                    "The work is complete."
+                )
+                chinese = await chat_translation_runtime.translate_completed_message(
+                    "工作已经完成。"
+                )
+            assert disabled == {"status": "disabled", "translation": ""}
+            assert skipped == {"status": "not_japanese", "translation": ""}
+            assert chinese == {"status": "not_japanese", "translation": ""}
+            translate.assert_not_awaited()
+        finally:
+            chat_translation_runtime.set_config({"chat_translation_subtitles_enabled": original})
+
+    asyncio.run(run())
+
+
+def test_chat_translate_uses_clean_display_text_without_writing_history() -> None:
+    async def run() -> None:
+        original_enabled = chat_translation_runtime.is_enabled()
+        history_before = [dict(item) for item in conversation_history.dialog]
+        try:
+            chat_translation_runtime.set_config({"chat_translation_subtitles_enabled": True})
+            with patch(
+                "server.wallpaper_subtitle_translator.translate_presentation_subtitle",
+                new=AsyncMock(return_value="工作已经完成。"),
+            ) as translate:
+                result = await ChatHandler().handle(
+                    Method.CHAT_TRANSLATE,
+                    {"text": "作業は終わったわ。", "turn_id": "turn-clean"},
+                )
+            assert result == {
+                "status": "translated",
+                "translation": "工作已经完成。",
+                "turn_id": "turn-clean",
+            }
+            translate.assert_awaited_once_with("作業は終わったわ。")
+            assert conversation_history.dialog == history_before
+        finally:
+            chat_translation_runtime.set_config(
+                {"chat_translation_subtitles_enabled": original_enabled}
+            )
+
+    asyncio.run(run())
+
+
+def test_chat_translation_output_uses_existing_subtitle_cleaner() -> None:
+    assert _clean_translation("```text\n翻译：工作已经完成。\n```") == "工作已经完成。"
+
+
+def test_system_setting_applies_chat_translation_toggle_without_restart() -> None:
+    async def run() -> None:
+        original = chat_translation_runtime.is_enabled()
+        handler = SystemHandler()
+        try:
+            handler._get_config = AsyncMock(  # type: ignore[method-assign]
+                return_value={"chat_translation_subtitles_enabled": True}
+            )
+            with patch("server.handlers.system_handler.bus.emit", new=AsyncMock()):
+                result = await handler._set_config(
+                    {"values": {"chat_translation_subtitles_enabled": True}}
+                )
+            assert result["values"]["chat_translation_subtitles_enabled"] is True
+            assert "chat_translation_subtitles_enabled" in result["updated"]
+        finally:
+            chat_translation_runtime.set_config({"chat_translation_subtitles_enabled": original})
+
+    asyncio.run(run())


### PR DESCRIPTION
## What and why

Add an opt-in Simplified Chinese subtitle directly below completed Japanese assistant text in the existing Electron Chat bubble.

This is the smallest coherent change because it:

- derives subtitles only from the already-clean `chat.complete.full_text` display text;
- keeps translations in renderer-only state, separate from `Message.text`, Session storage, TTS, Provider context, and conversation history;
- reuses the established Wallpaper subtitle provider/model selection, timeout, and output cleaning;
- gives Chat its own runtime-only, default-off setting instead of coupling it to Wallpaper caption visibility.

Linked Issue for product-semantic or public-contract changes: not required; this is a default-off presentation-only UI change.

## Change class

- [x] Routine fix, documentation, test, maintenance, or presentation-only UI
- [ ] Product-semantic or public-contract change discussed in the linked Issue
- [ ] Isolated, default-off experiment

Owning layer: Electron Chat presentation and the server presentation-subtitle adapter.

User-visible effect, or `none`: when enabled, completed Japanese assistant messages show a muted Simplified Chinese subtitle below the original text inside the same bubble.

Compatibility or migration impact, or `none`: none. The setting defaults off, is runtime-only like the existing Wallpaper caption setting, and adds no dependency or durable schema.

## Evidence

Commands and manual journeys run:

- `python -m ruff check .`
- `python tools/architecture/generate_views.py --check`
- focused Python Chat/Session/Settings/history suites: 70 passed
- `npm ci`
- `npm test`: 4 passed
- `npm run build`
- `npm audit --audit-level=high`: 0 vulnerabilities in the Electron lock
- manual GUI review accepted by the requester with the subtitle inside the existing assistant bubble

- [x] Relevant Python tests pass
- [x] CPU/model-less baseline remains supported
- [x] Electron `npm run build` passes when Electron code changed
- [x] Dependency audit passes when dependencies changed
- [ ] Before/after screenshots are attached for visible UI changes (manual GUI review completed; no screenshot attached)
- [x] Documentation/examples are updated for changed settings or contracts (the runtime setting is described inline in Settings; no external contract changed)

## Final check

- [x] This PR addresses one coherent problem without unrelated cleanup
- [x] It does not add a speculative API, fallback, or compatibility path
- [x] No secrets, local state, model weights, voice material, or restricted assets are included
- [x] Third-party notices and provenance are preserved