### PR TITLE
fix(ui): Wallpaper按钮点击立刻返回高亮状态

### DIFF
--- a/electron/src/renderer/App.tsx
+++ b/electron/src/renderer/App.tsx
@@ -104,6 +104,7 @@ function AmadeusApp() {
   const handleToggleWallpaper = useCallback(async () => {
     const next = !wallpaperActive
     setPage('chat')
+    setWallpaperActive(next)
 
     if (next) {
       if (renderActive) {
@@ -114,10 +115,10 @@ function AmadeusApp() {
       }
       try {
         const res = await send('wallpaper.start', ELECTRON_SLICE_START_PARAMS)
-        setWallpaperActive(res?.status !== 'error')
-        if (res?.status !== 'error') await syncElectronSliceHost(res)
+        if (res?.status === 'error') setWallpaperActive(false)   // 失败回退
+        else await syncElectronSliceHost(res)
       } catch {
-        setWallpaperActive(false)
+        setWallpaperActive(false) //失败回退
       }
     } else {
       try { await send('wallpaper.stop', {}) } catch {}


### PR DESCRIPTION
点击 Sidebar 的 Wallpaper 按钮后，高亮状态要等后端 `wallpaper.start` 返回才更新，
等待期间按钮没有视觉反馈；而同旁的 Render 按钮是点击立即高亮的，行为不一致。

修复：在 `handleToggleWallpaper` 中点击时立即 `setWallpaperActive(next)`，
仅在启动失败时回退为 `false`，与 `handleToggleRender` 的行为保持一致。