### PR TITLE
fix(asr): keep barge-in capture while speech continues

### DIFF
--- a/asr/mic_input_service.py
+++ b/asr/mic_input_service.py
@@ -270,7 +270,15 @@ class MicInputService:
         energy_end_chunks = max(1, int(max(1, int(energy_end_ms)) / chunk_ms))
         energy_end_rms = max(0.0, float(energy_end_rms))
         handoff_max_capture_sec = max(0.1, float(handoff_max_capture_sec))
+        max_speech_sec = max(0.1, float(max_speech_sec))
         silence_chunks = 0
+        # A handoff starts with buffered speech, so ``speech_started`` alone
+        # cannot prove that this fresh Conversation VAD iterator owns the live
+        # utterance.  Keep the short recovery watchdog until this iterator sees
+        # its own start event.  Once it does, normal VAD/energy/max-speech
+        # endpointing owns the utterance and the watchdog must not cut a user
+        # off merely because they have spoken for five seconds.
+        handoff_vad_owned = False
         # 两段式投机端点：短静音先行触发 on_probable_end(部分音频)，
         # 说话恢复则 on_probable_end_cancelled() 作废并重新武装。
         probable_end_chunks = (
@@ -303,7 +311,10 @@ class MicInputService:
         echo_dropped = False
         preroll_buf: deque[np.ndarray] = deque(maxlen=preroll_chunks)
         cursor = self.cursor()
-        deadline = time.monotonic() + float(timeout_s)
+        # ``timeout_s`` is the wait-for-speech-start deadline.  It must not
+        # shorten an utterance that started late; active speech has its own
+        # bounded ``max_speech_sec`` deadline below.
+        speech_start_deadline = time.monotonic() + max(0.0, float(timeout_s))
 
         def finish_audio(reason: str) -> np.ndarray | None:
             nonlocal echo_dropped
@@ -341,7 +352,16 @@ class MicInputService:
             return audio
 
         try:
-            while time.monotonic() < deadline and not self._stop_event.is_set():
+            while not self._stop_event.is_set():
+                now = time.monotonic()
+                if not speech_started and now >= speech_start_deadline:
+                    break
+                if (
+                    speech_started
+                    and capture_started_at > 0
+                    and now - capture_started_at >= max_speech_sec
+                ):
+                    return finish_audio("max_speech")
                 frame = cursor.read(timeout=0.25)
                 if frame is None:
                     continue
@@ -356,18 +376,22 @@ class MicInputService:
 
                 vad_out = vad_iter(torch.from_numpy(chunk_np), return_seconds=False)
                 if vad_out is not None:
-                    if "start" in vad_out and not speech_started:
-                        speech_started = True
-                        speech_chunks = list(preroll_buf)
-                        speech_raw_chunks = list(preroll_buf)
-                        speech_times = []
-                        capture_started_at = time.monotonic()
-                        silence_chunks = 0
-                        if on_speech_start is not None:
-                            try:
-                                on_speech_start()
-                            except Exception:
-                                logger.debug("[MicInput] speech-start callback failed", exc_info=True)
+                    if "start" in vad_out:
+                        if handoff_capture and not handoff_vad_owned:
+                            handoff_vad_owned = True
+                            logger.info("[MicInput] handoff Conversation VAD took ownership")
+                        if not speech_started:
+                            speech_started = True
+                            speech_chunks = list(preroll_buf)
+                            speech_raw_chunks = list(preroll_buf)
+                            speech_times = []
+                            capture_started_at = time.monotonic()
+                            silence_chunks = 0
+                            if on_speech_start is not None:
+                                try:
+                                    on_speech_start()
+                                except Exception:
+                                    logger.debug("[MicInput] speech-start callback failed", exc_info=True)
                     elif "end" in vad_out and speech_started:
                         audio = finish_audio("vad_end")
                         if echo_dropped:
@@ -419,6 +443,7 @@ class MicInputService:
                         continue
                     if (
                         handoff_capture
+                        and not handoff_vad_owned
                         and capture_started_at > 0
                         and time.monotonic() - capture_started_at >= handoff_max_capture_sec
                     ):

--- a/config/settings.py
+++ b/config/settings.py
@@ -390,6 +390,9 @@ ASR_LISTEN_TIMEOUT_SECONDS = _float("ASR_LISTEN_TIMEOUT_SECONDS", 15.0)
 ASR_PREROLL_MS = _int("ASR_PREROLL_MS", 500)
 ASR_ENERGY_END_RMS = _float("ASR_ENERGY_END_RMS", 0.008)
 ASR_ENERGY_END_MS = _int("ASR_ENERGY_END_MS", 450)
+# Recovery watchdog while a post-barge-in capture still lacks ownership from
+# its fresh Conversation VAD iterator.  This is not the user's speech limit;
+# after VAD takeover, ASR_MAX_SPEECH_SECONDS is the absolute bound.
 ASR_HANDOFF_MAX_CAPTURE_SECONDS = _float("ASR_HANDOFF_MAX_CAPTURE_SECONDS", 5.0)
 # 两段式投机端点：短静音（下值）先把已捕获音频提交给 ASR 后端并行转写，
 # 长静音（ASR_VAD_SILENCE_MS / ASR_ENERGY_END_MS）确认端点后若说话未恢复

--- a/docs/barge_in_aec_interrupt_notes.md
+++ b/docs/barge_in_aec_interrupt_notes.md
@@ -467,7 +467,13 @@ Root cause:
 Final rule:
 
 - Handoff capture must not depend only on VAD end.
-- Handoff capture needs an energy-end fallback and a short max duration cap.
+- Handoff capture needs an energy-end fallback and a short recovery watchdog.
+- The watchdog applies only until the fresh Conversation VAD iterator observes
+  its own speech start. Once that iterator owns the live utterance, normal
+  VAD/energy endpointing and `ASR_MAX_SPEECH_SECONDS` own completion; the
+  watchdog must not commit a still-speaking user after five seconds.
+- `ASR_LISTEN_TIMEOUT_SECONDS` bounds waiting for speech to start. It does not
+  shorten speech that has already started.
 - Log capture finish reason and duration, then judge latency from those logs
   before blaming the recognizer or provider.
 

--- a/tests/test_mic_input_handoff_endpointing.py
+++ b/tests/test_mic_input_handoff_endpointing.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import numpy as np
 
@@ -111,9 +112,9 @@ def _capture(
     )
     monkeypatch.setattr(mic_module.time, "monotonic", cursor.clock.monotonic)
 
-    import silero_vad
-
-    monkeypatch.setattr(silero_vad, "VADIterator", lambda *args, **kwargs: vad)
+    fake_silero_vad = ModuleType("silero_vad")
+    fake_silero_vad.VADIterator = lambda *args, **kwargs: vad
+    monkeypatch.setitem(sys.modules, "silero_vad", fake_silero_vad)
     monkeypatch.setattr(
         echo_guard,
         "should_drop_handoff_candidate",

--- a/tests/test_mic_input_handoff_endpointing.py
+++ b/tests/test_mic_input_handoff_endpointing.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+
+import asr.echo_guard as echo_guard
+import asr.mic_input_service as mic_module
+from asr.mic_input_service import MicFrame, MicInputService
+
+
+_SAMPLE_RATE = 16_000
+_CHUNK_SAMPLES = 512
+_CHUNK_SECONDS = _CHUNK_SAMPLES / _SAMPLE_RATE
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        # Capture code treats 0.0 as "not started"; use a realistic monotonic
+        # origin so the tests exercise the production predicates.
+        self.now = 100.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += float(seconds)
+
+
+class _ScriptedCursor:
+    def __init__(
+        self,
+        clock: _FakeClock,
+        *,
+        frame_count: int,
+        rms: float = 0.05,
+        value: float = 0.25,
+    ) -> None:
+        self.clock = clock
+        self.frame_count = int(frame_count)
+        self.rms = float(rms)
+        self.value = float(value)
+        self.read_count = 0
+
+    def read(self, timeout: float = 0.25) -> MicFrame | None:
+        if self.read_count >= self.frame_count:
+            self.clock.advance(timeout)
+            return None
+        self.clock.advance(_CHUNK_SECONDS)
+        seq = self.read_count
+        self.read_count += 1
+        audio = np.full(_CHUNK_SAMPLES, self.value, dtype=np.float32)
+        return MicFrame(
+            seq=seq,
+            timestamp=self.clock.monotonic(),
+            audio=audio,
+            rms=self.rms,
+            raw_audio=audio.copy(),
+        )
+
+
+class _ScriptedVAD:
+    def __init__(self, events: dict[int, dict[str, int]] | None = None) -> None:
+        self.events = dict(events or {})
+        self.call_count = 0
+        self.reset_count = 0
+
+    def __call__(self, _chunk, return_seconds: bool = False):
+        del return_seconds
+        self.call_count += 1
+        return self.events.get(self.call_count)
+
+    def reset_states(self) -> None:
+        self.reset_count += 1
+
+
+def _handoff_frames(count: int = 40) -> list[MicFrame]:
+    frames: list[MicFrame] = []
+    for seq in range(count):
+        audio = np.full(_CHUNK_SAMPLES, -0.25, dtype=np.float32)
+        frames.append(
+            MicFrame(
+                seq=seq,
+                timestamp=99.0 + seq * _CHUNK_SECONDS,
+                audio=audio,
+                rms=0.05,
+                raw_audio=audio.copy(),
+            )
+        )
+    return frames
+
+
+def _capture(
+    monkeypatch,
+    *,
+    cursor: _ScriptedCursor,
+    vad: _ScriptedVAD,
+    handoff_frames: list[MicFrame] | None = None,
+    timeout_s: float = 15.0,
+    max_speech_sec: float = 30.0,
+    handoff_max_capture_sec: float = 5.0,
+) -> np.ndarray | None:
+    service = MicInputService()
+    monkeypatch.setattr(service, "start", lambda *args, **kwargs: None)
+    monkeypatch.setattr(service, "cursor", lambda *args, **kwargs: cursor)
+    monkeypatch.setattr(
+        service,
+        "consume_handoff_frames",
+        lambda *args, **kwargs: list(handoff_frames or []),
+    )
+    monkeypatch.setattr(mic_module.time, "monotonic", cursor.clock.monotonic)
+
+    import silero_vad
+
+    monkeypatch.setattr(silero_vad, "VADIterator", lambda *args, **kwargs: vad)
+    monkeypatch.setattr(
+        echo_guard,
+        "should_drop_handoff_candidate",
+        lambda **kwargs: SimpleNamespace(drop=False, reason="near_end_or_uncertain"),
+    )
+
+    return service.capture_utterance(
+        vad_model=object(),
+        threshold=0.45,
+        timeout_s=timeout_s,
+        min_silence_ms=350,
+        speech_pad_ms=60,
+        min_speech_ms=150,
+        max_speech_sec=max_speech_sec,
+        preroll_ms=500,
+        energy_end_rms=0.008,
+        energy_end_ms=450,
+        handoff_max_capture_sec=handoff_max_capture_sec,
+        consume_handoff=True,
+    )
+
+
+def test_handoff_vad_takeover_disarms_recovery_watchdog_and_preserves_preroll(
+    monkeypatch,
+    caplog,
+) -> None:
+    clock = _FakeClock()
+    cursor = _ScriptedCursor(clock, frame_count=220)
+    # Conversation VAD takes ownership immediately, then reports the real end
+    # after more than six seconds of continued live speech.
+    vad = _ScriptedVAD({1: {"start": 0}, 190: {"end": 1}})
+    handoff = _handoff_frames()
+
+    caplog.set_level(logging.INFO, logger="asr.mic_input_service")
+    audio = _capture(
+        monkeypatch,
+        cursor=cursor,
+        vad=vad,
+        handoff_frames=handoff,
+    )
+
+    assert audio is not None
+    assert cursor.read_count == 190
+    assert "handoff Conversation VAD took ownership" in caplog.text
+    assert "reason=vad_end" in caplog.text
+    assert "reason=handoff_max" not in caplog.text
+    # The endpoint change must not discard or rewrite the existing handoff
+    # pre-roll.  It remains the prefix of the recognizer waveform.
+    np.testing.assert_array_equal(audio[:_CHUNK_SAMPLES], handoff[0].audio)
+    assert audio.size >= len(handoff) * _CHUNK_SAMPLES
+
+
+def test_handoff_without_vad_takeover_keeps_five_second_watchdog(
+    monkeypatch,
+    caplog,
+) -> None:
+    clock = _FakeClock()
+    cursor = _ScriptedCursor(clock, frame_count=400)
+    vad = _ScriptedVAD()
+
+    caplog.set_level(logging.INFO, logger="asr.mic_input_service")
+    audio = _capture(
+        monkeypatch,
+        cursor=cursor,
+        vad=vad,
+        handoff_frames=_handoff_frames(),
+    )
+
+    assert audio is not None
+    assert 150 <= cursor.read_count <= 160
+    assert "reason=handoff_max" in caplog.text
+    assert "handoff Conversation VAD took ownership" not in caplog.text
+
+
+def test_wait_for_speech_timeout_does_not_shorten_late_started_utterance(
+    monkeypatch,
+    caplog,
+) -> None:
+    clock = _FakeClock()
+    cursor = _ScriptedCursor(clock, frame_count=700)
+    # Speech begins after about 14 seconds of waiting and continues for about
+    # six more seconds.  The 15-second wait-for-start timeout must not truncate
+    # it one second after it begins.
+    vad = _ScriptedVAD({438: {"start": 0}, 625: {"end": 1}})
+
+    caplog.set_level(logging.INFO, logger="asr.mic_input_service")
+    audio = _capture(monkeypatch, cursor=cursor, vad=vad)
+
+    assert audio is not None
+    assert cursor.read_count == 625
+    assert audio.size / _SAMPLE_RATE > 5.5
+    assert "reason=vad_end" in caplog.text
+    assert "reason=timeout" not in caplog.text
+
+
+def test_wait_for_speech_still_times_out_when_no_speech_starts(monkeypatch) -> None:
+    clock = _FakeClock()
+    cursor = _ScriptedCursor(clock, frame_count=700, rms=0.0, value=0.0)
+    vad = _ScriptedVAD()
+
+    audio = _capture(monkeypatch, cursor=cursor, vad=vad)
+
+    assert audio is None
+    assert 468 <= cursor.read_count <= 470
+
+
+def test_vad_owned_handoff_still_honors_absolute_max_speech(monkeypatch, caplog) -> None:
+    clock = _FakeClock()
+    cursor = _ScriptedCursor(clock, frame_count=400)
+    vad = _ScriptedVAD({1: {"start": 0}})
+
+    caplog.set_level(logging.INFO, logger="asr.mic_input_service")
+    audio = _capture(
+        monkeypatch,
+        cursor=cursor,
+        vad=vad,
+        handoff_frames=_handoff_frames(),
+        max_speech_sec=7.0,
+    )
+
+    assert audio is not None
+    assert cursor.read_count > 160  # passed the old five-second handoff cap
+    assert audio.size / _SAMPLE_RATE <= 7.1
+    assert "reason=max_speech" in caplog.text
+    assert "reason=handoff_max" not in caplog.text


### PR DESCRIPTION
## Summary

- keep the 5-second handoff limit as a recovery watchdog until Conversation VAD takes ownership
- let VAD-owned speech continue to the real VAD/energy endpoint or absolute speech limit
- make the 15-second listen timeout apply only while waiting for speech to start
- preserve the existing barge-in, echo guard, pre-roll, and interrupt paths

## Verification

- 41 related ASR/interrupt/epoch/pending tests passed
- real-device acceptance captured one `handoff=True` utterance for 12.64 seconds and finished with `energy_end`, without `handoff_max` or a duplicate user turn

Relates to #23. The issue should remain open for follow-up observation and the separate recognition-quality report.

Thanks @aryecatcher for the detailed report and runtime logs.