### PR TITLE
fix(asr): prepare barge-in VAD without blocking playback

### DIFF
--- a/asr/barge_in_detector.py
+++ b/asr/barge_in_detector.py
@@ -52,6 +52,8 @@ class BargeInDetector:
         self._on_barge_in = on_barge_in
         self._on_debug = on_debug
         self._thread: threading.Thread | None = None
+        self._preparation_thread: threading.Thread | None = None
+        self._start_requested = False
         self._stop_event = threading.Event()
         self._loop: asyncio.AbstractEventLoop | None = None
         self._vad_model = None
@@ -66,25 +68,47 @@ class BargeInDetector:
 
     def start(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
         with self._lock:
-            if self.running:
-                return
             self._loop = loop or asyncio.get_event_loop()
-            self._triggered = False
-            self._stop_event.clear()
-            self._thread = threading.Thread(
-                target=self._run,
-                name="barge-in-detector",
-                daemon=True,
-            )
-            self._thread.start()
+            self._start_requested = True
+            if self._vad_capability is None:
+                if self._preparation_thread is None:
+                    self._preparation_thread = threading.Thread(
+                        target=self._prepare_vad,
+                        name="barge-in-vad-prepare",
+                        daemon=True,
+                    )
+                    self._preparation_thread.start()
+                return
+            self._start_ready_locked()
+
+    def _start_ready_locked(self) -> None:
+        # Called with _lock held. Only a successful preparation can open the
+        # microphone, and a completed preparation cannot undo stop().
+        if not self._start_requested or self._vad_capability != ("ready", "") or self.running:
+            return
+        self._triggered = False
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="barge-in-detector",
+            daemon=True,
+        )
+        self._thread.start()
 
     def stop(self) -> None:
-        self._stop_event.set()
-        thread = self._thread
+        with self._lock:
+            self._start_requested = False
+            self._stop_event.set()
+            thread = self._thread
+        # Cold model loading has no microphone resource to drain. Let it finish
+        # and cache its result without blocking playback/interrupt callbacks.
         if thread and thread.is_alive() and thread is not threading.current_thread():
             thread.join(timeout=1.0)
-        if thread is None or not thread.is_alive() or thread is threading.current_thread():
-            self._thread = None
+        with self._lock:
+            if self._thread is thread and (
+                thread is None or not thread.is_alive() or thread is threading.current_thread()
+            ):
+                self._thread = None
 
     def _is_tts_playing(self) -> bool:
         try:
@@ -92,35 +116,22 @@ class BargeInDetector:
         except Exception:
             return False
 
-    def _ensure_vad(self):
-        if self._vad_model is None:
-            from silero_vad import load_silero_vad
+    def _prepare_vad(self) -> None:
+        """Probe once off the playback loop, independently of ASRManager.
 
-            self._vad_model = load_silero_vad()
-            self._vad_model.eval()
-        return self._vad_model
-
-    def vad_status(self) -> tuple[str, str]:
-        """Three-state VAD capability fact: ("ready" | "fallback" | "degraded", reason).
-
-        The barge-in thread depends on silero-vad/torch (the L3 voice tier),
-        so the startup boundary must consult this before spawning the thread:
-        on an L2 install a config-only gate would start a doomed thread that
-        reports barge_in_error on every sentence. Absent dependency ->
-        documented fallback; installed but broken -> degraded with the reason
-        kept observable (never disguised as absence).
-
-        Probing is lazy (never in __init__: L1/L2 bootstrap must stay
-        importable) and happens exactly once per detector instance — later
-        playback sentences re-read the cache instead of re-failing. This
-        detector owns its own VAD model (see _ensure_vad) and is
-        intentionally independent of the ASRManager lazy lifecycle, whose
-        manager is only created when ASR first listens.
+        Cache missing/broken dependencies before any listening thread starts.
+        The request under _lock is authoritative: stop cancels a pending start,
+        while a later sentence may request listening using the same preparation.
         """
-        # Called from the event-loop thread only (startup boundary); no lock.
-        if self._vad_capability is None:
-            self._vad_capability = self._probe_vad_capability()
-        return self._vad_capability
+        capability = self._probe_vad_capability()
+        with self._lock:
+            self._vad_capability = capability
+            self._preparation_thread = None
+            if capability[0] != "ready":
+                state, reason = capability
+                logger.info("[BargeIn] detector disabled: vad %s%s", state, f": {reason}" if reason else "")
+                return
+            self._start_ready_locked()
 
     def _probe_vad_capability(self) -> tuple[str, str]:
         try:
@@ -139,8 +150,7 @@ class BargeInDetector:
             model.eval()
         except Exception as exc:
             return "degraded", f"{type(exc).__name__}: {exc}"
-        # Cache the loaded model so _ensure_vad() in the detector thread
-        # reuses it instead of loading a second copy.
+        # The listening thread reuses this model; it never performs a cold load.
         self._vad_model = model
         return "ready", ""
 
@@ -202,9 +212,7 @@ class BargeInDetector:
     def _run(self) -> None:
         try:
             delay = max(0.0, float(BARGE_IN_START_DELAY_MS) / 1000.0)
-            if delay:
-                time.sleep(delay)
-            if self._stop_event.is_set() or not self._is_tts_playing():
+            if self._stop_event.wait(delay) or not self._is_tts_playing():
                 return
 
             from silero_vad import VADIterator
@@ -215,7 +223,7 @@ class BargeInDetector:
             from asr.mic_input_service import get_mic_input_service
 
             vad_iter = VADIterator(
-                self._ensure_vad(),
+                self._vad_model,
                 threshold=float(BARGE_IN_VAD_THRESHOLD),
                 sampling_rate=_SAMPLE_RATE,
                 min_silence_duration_ms=180,

--- a/asr/barge_in_detector.py
+++ b/asr/barge_in_detector.py
@@ -55,6 +55,7 @@ class BargeInDetector:
         self._stop_event = threading.Event()
         self._loop: asyncio.AbstractEventLoop | None = None
         self._vad_model = None
+        self._vad_capability: tuple[str, str] | None = None
         self._triggered = False
         self._lock = threading.Lock()
 
@@ -98,6 +99,50 @@ class BargeInDetector:
             self._vad_model = load_silero_vad()
             self._vad_model.eval()
         return self._vad_model
+
+    def vad_status(self) -> tuple[str, str]:
+        """Three-state VAD capability fact: ("ready" | "fallback" | "degraded", reason).
+
+        The barge-in thread depends on silero-vad/torch (the L3 voice tier),
+        so the startup boundary must consult this before spawning the thread:
+        on an L2 install a config-only gate would start a doomed thread that
+        reports barge_in_error on every sentence. Absent dependency ->
+        documented fallback; installed but broken -> degraded with the reason
+        kept observable (never disguised as absence).
+
+        Probing is lazy (never in __init__: L1/L2 bootstrap must stay
+        importable) and happens exactly once per detector instance — later
+        playback sentences re-read the cache instead of re-failing. This
+        detector owns its own VAD model (see _ensure_vad) and is
+        intentionally independent of the ASRManager lazy lifecycle, whose
+        manager is only created when ASR first listens.
+        """
+        # Called from the event-loop thread only (startup boundary); no lock.
+        if self._vad_capability is None:
+            self._vad_capability = self._probe_vad_capability()
+        return self._vad_capability
+
+    def _probe_vad_capability(self) -> tuple[str, str]:
+        try:
+            from silero_vad import load_silero_vad
+        except ModuleNotFoundError as exc:
+            if exc.name == "silero_vad":
+                # Absent dependency: documented L2 fallback.
+                return "fallback", ""
+            # silero-vad present but a dependency (e.g. torch) missing:
+            # a broken install must stay observable, not fake absence.
+            return "degraded", f"missing dependency {exc.name}"
+        except Exception as exc:  # e.g. torch DLL/ABI failure raised at import
+            return "degraded", f"{type(exc).__name__}: {exc}"
+        try:
+            model = load_silero_vad()
+            model.eval()
+        except Exception as exc:
+            return "degraded", f"{type(exc).__name__}: {exc}"
+        # Cache the loaded model so _ensure_vad() in the detector thread
+        # reuses it instead of loading a second copy.
+        self._vad_model = model
+        return "ready", ""
 
     def _emit_debug(self, **payload: Any) -> None:
         callback = self._on_debug

--- a/server/app.py
+++ b/server/app.py
@@ -290,6 +290,32 @@ def _http_request_authenticated(headers, auth_policy: LocalAuthPolicy) -> bool:
 
 # bootstrap.
 
+def _barge_in_start_decision(manager, *, config_enabled: bool) -> tuple[bool, str]:
+    """barge-in 检测线程的启动边界判定，返回 (是否启动, 不可用原因)。
+
+    配置开关只是必要条件：检测线程依赖 silero-vad/torch（L3 能力层）。
+    若只看配置，L2 安装上每个播放句都会拉起一个必败线程并反复上报
+    barge_in_error。能力判定只消费 ASR manager 的公开 vad_status()
+    （ready/fallback/degraded 三态），不在此二次探测 import：
+
+    - ready:    能力真实存在，允许启动
+    - fallback: vad 层未安装（L2 文档化降级）→ 拒绝启动
+    - degraded: 已安装但加载失败 → 拒绝启动，reason 保持可观察，不得伪装成缺席
+    - manager 尚未创建 → 未观察到语音能力，拒绝启动
+
+    不可用事实由调用方记一条日志；vad 状态本身已由 runtime_status 持续
+    公开，barge-in 禁用是其直接推论，不新增公开字段。
+    """
+    if not config_enabled:
+        return False, ""
+    if manager is None:
+        return False, "asr manager not initialized (no voice capability observed)"
+    state, reason = manager.vad_status()
+    if state == "ready":
+        return True, ""
+    return False, f"vad {state}" + (f": {reason}" if reason else "")
+
+
 async def bootstrap(port: int = 17777) -> None:
     """Mirrors main.py's main() init sequence, minus GUI."""
     global vts_manager, player, playback_manager, tts_runtime, asr_manager, wake_service
@@ -854,9 +880,6 @@ async def bootstrap(port: int = 17777) -> None:
             return True
         return False
 
-    def _barge_in_enabled() -> bool:
-        return bool(AEC_REALTIME_ENABLED and AEC_REALTIME_BARGE_IN)
-
     logger.info(
         "aec realtime enabled=%s barge_in=%s delay_ms=%s tail_guard_ms=%s",
         AEC_REALTIME_ENABLED,
@@ -871,6 +894,8 @@ async def bootstrap(port: int = 17777) -> None:
     _expr_ctrl.configure(vts_manager=vts_manager)
     server_loop = asyncio.get_running_loop()
     _last_barge_in_interrupt_at = 0.0
+    # 能力不可用只记一次日志：避免每个播放句刷屏，禁用事实仍可观察。
+    _barge_in_unavailable_logged = False
 
     def _env_truthy(name: str, default: bool = False) -> bool:
         value = os.environ.get(name)
@@ -941,7 +966,16 @@ async def bootstrap(port: int = 17777) -> None:
     )
 
     def _start_barge_in_detector() -> None:
-        if not _barge_in_enabled():
+        nonlocal _barge_in_unavailable_logged
+        start, unavailable = _barge_in_start_decision(
+            asr_manager,
+            config_enabled=bool(AEC_REALTIME_ENABLED and AEC_REALTIME_BARGE_IN),
+        )
+        if not start:
+            # 配置关闭是既定的关闭态（启动日志已覆盖），不另记日志。
+            if unavailable and not _barge_in_unavailable_logged:
+                _barge_in_unavailable_logged = True
+                logger.info("[BargeIn] detector disabled: %s", unavailable)
             return
         if barge_in_detector.running:
             return

--- a/server/app.py
+++ b/server/app.py
@@ -290,27 +290,28 @@ def _http_request_authenticated(headers, auth_policy: LocalAuthPolicy) -> bool:
 
 # bootstrap.
 
-def _barge_in_start_decision(manager, *, config_enabled: bool) -> tuple[bool, str]:
+def _barge_in_start_decision(detector, *, config_enabled: bool) -> tuple[bool, str]:
     """barge-in 检测线程的启动边界判定，返回 (是否启动, 不可用原因)。
 
     配置开关只是必要条件：检测线程依赖 silero-vad/torch（L3 能力层）。
     若只看配置，L2 安装上每个播放句都会拉起一个必败线程并反复上报
-    barge_in_error。能力判定只消费 ASR manager 的公开 vad_status()
-    （ready/fallback/degraded 三态），不在此二次探测 import：
+    barge_in_error。能力判定委托给 BargeInDetector.vad_status()——
+    detector 独立拥有自己的 VAD 模型加载（_ensure_vad），不依赖
+    ASRManager 的惰性生命周期（那个 manager 只在 ASR 首次监听时才
+    创建、空闲时卸载），因此键盘聊天后首次播放、空闲卸载后的播放
+    等旅程都能被正确判定。三态：
 
     - ready:    能力真实存在，允许启动
     - fallback: vad 层未安装（L2 文档化降级）→ 拒绝启动
     - degraded: 已安装但加载失败 → 拒绝启动，reason 保持可观察，不得伪装成缺席
-    - manager 尚未创建 → 未观察到语音能力，拒绝启动
 
-    不可用事实由调用方记一条日志；vad 状态本身已由 runtime_status 持续
-    公开，barge-in 禁用是其直接推论，不新增公开字段。
+    探测在 detector 内只发生一次并缓存，确认不可用后后续播放句直接读
+    缓存，不再拉起线程、不再反复报错。不可用事实由调用方记一条日志；
+    不新增公开字段。
     """
     if not config_enabled:
         return False, ""
-    if manager is None:
-        return False, "asr manager not initialized (no voice capability observed)"
-    state, reason = manager.vad_status()
+    state, reason = detector.vad_status()
     if state == "ready":
         return True, ""
     return False, f"vad {state}" + (f": {reason}" if reason else "")
@@ -968,7 +969,7 @@ async def bootstrap(port: int = 17777) -> None:
     def _start_barge_in_detector() -> None:
         nonlocal _barge_in_unavailable_logged
         start, unavailable = _barge_in_start_decision(
-            asr_manager,
+            barge_in_detector,
             config_enabled=bool(AEC_REALTIME_ENABLED and AEC_REALTIME_BARGE_IN),
         )
         if not start:

--- a/server/app.py
+++ b/server/app.py
@@ -290,33 +290,6 @@ def _http_request_authenticated(headers, auth_policy: LocalAuthPolicy) -> bool:
 
 # bootstrap.
 
-def _barge_in_start_decision(detector, *, config_enabled: bool) -> tuple[bool, str]:
-    """barge-in 检测线程的启动边界判定，返回 (是否启动, 不可用原因)。
-
-    配置开关只是必要条件：检测线程依赖 silero-vad/torch（L3 能力层）。
-    若只看配置，L2 安装上每个播放句都会拉起一个必败线程并反复上报
-    barge_in_error。能力判定委托给 BargeInDetector.vad_status()——
-    detector 独立拥有自己的 VAD 模型加载（_ensure_vad），不依赖
-    ASRManager 的惰性生命周期（那个 manager 只在 ASR 首次监听时才
-    创建、空闲时卸载），因此键盘聊天后首次播放、空闲卸载后的播放
-    等旅程都能被正确判定。三态：
-
-    - ready:    能力真实存在，允许启动
-    - fallback: vad 层未安装（L2 文档化降级）→ 拒绝启动
-    - degraded: 已安装但加载失败 → 拒绝启动，reason 保持可观察，不得伪装成缺席
-
-    探测在 detector 内只发生一次并缓存，确认不可用后后续播放句直接读
-    缓存，不再拉起线程、不再反复报错。不可用事实由调用方记一条日志；
-    不新增公开字段。
-    """
-    if not config_enabled:
-        return False, ""
-    state, reason = detector.vad_status()
-    if state == "ready":
-        return True, ""
-    return False, f"vad {state}" + (f": {reason}" if reason else "")
-
-
 async def bootstrap(port: int = 17777) -> None:
     """Mirrors main.py's main() init sequence, minus GUI."""
     global vts_manager, player, playback_manager, tts_runtime, asr_manager, wake_service
@@ -881,6 +854,9 @@ async def bootstrap(port: int = 17777) -> None:
             return True
         return False
 
+    def _barge_in_enabled() -> bool:
+        return bool(AEC_REALTIME_ENABLED and AEC_REALTIME_BARGE_IN)
+
     logger.info(
         "aec realtime enabled=%s barge_in=%s delay_ms=%s tail_guard_ms=%s",
         AEC_REALTIME_ENABLED,
@@ -895,8 +871,6 @@ async def bootstrap(port: int = 17777) -> None:
     _expr_ctrl.configure(vts_manager=vts_manager)
     server_loop = asyncio.get_running_loop()
     _last_barge_in_interrupt_at = 0.0
-    # 能力不可用只记一次日志：避免每个播放句刷屏，禁用事实仍可观察。
-    _barge_in_unavailable_logged = False
 
     def _env_truthy(name: str, default: bool = False) -> bool:
         value = os.environ.get(name)
@@ -967,16 +941,7 @@ async def bootstrap(port: int = 17777) -> None:
     )
 
     def _start_barge_in_detector() -> None:
-        nonlocal _barge_in_unavailable_logged
-        start, unavailable = _barge_in_start_decision(
-            barge_in_detector,
-            config_enabled=bool(AEC_REALTIME_ENABLED and AEC_REALTIME_BARGE_IN),
-        )
-        if not start:
-            # 配置关闭是既定的关闭态（启动日志已覆盖），不另记日志。
-            if unavailable and not _barge_in_unavailable_logged:
-                _barge_in_unavailable_logged = True
-                logger.info("[BargeIn] detector disabled: %s", unavailable)
+        if not _barge_in_enabled():
             return
         if barge_in_detector.running:
             return

--- a/tests/test_barge_in_capability_gate.py
+++ b/tests/test_barge_in_capability_gate.py
@@ -1,147 +1,248 @@
-"""L2 tier contract: barge-in must not start a doomed detector thread.
-
-On an L2 install (silero-vad/torch absent) with barge-in config enabled, the
-startup boundary must keep the detector off with an observable degradation
-instead of spawning a thread that fails on import and emits barge_in_error on
-every sentence. The capability fact is owned by BargeInDetector (it loads its
-own VAD model) and must NOT be inferred from the ASRManager lifecycle: the
-manager is created lazily when ASR first listens and cleared on idle unload,
-while the detector only needs its own VAD — so keyboard-chat-then-first-
-playback and post-unload journeys must still pass the gate.
-"""
-
+"""VAD preparation must not block playback or outlive a cancelled start."""
 from __future__ import annotations
 
+import asyncio
+import builtins
 import subprocess
 import sys
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+import numpy as np
+import pytest
 
-# L2 = audio stack present, vad tier (silero-vad + its torch dependency) absent.
-_L3_ONLY_MODULES = ("silero_vad", "torch", "torchaudio")
-
-_PROBE = f"""
-import sys
-import types
-
-_BLOCKED = {set(_L3_ONLY_MODULES)!r}
-
-class _Blocker:
-    # Simulate a missing package for `import` statements: the finder raises
-    # ModuleNotFoundError, which is what a real L2 install raises.
-    def find_spec(self, name, path=None, target=None):
-        if name.split(".")[0] in _BLOCKED:
-            raise ModuleNotFoundError(
-                f"{{name}} is not part of the L2 install", name=name
-            )
-        return None
-
-sys.meta_path.insert(0, _Blocker())
-for mod in list(sys.modules):
-    if mod.split(".")[0] in _BLOCKED:
-        del sys.modules[mod]
-
-# Prove the mask is real: the vad tier is genuinely absent in this process.
-try:
-    import silero_vad  # noqa: F401
-except ModuleNotFoundError:
-    pass
-else:
-    raise SystemExit("silero_vad unexpectedly importable under the L2 mask")
-
-import server.app
 from asr.barge_in_detector import BargeInDetector
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 async def _noop() -> None:
-    return None
+    pass
 
 
-def _detector():
-    return BargeInDetector(tts_playing_fn=lambda: False, on_barge_in=_noop)
+def _detector() -> BargeInDetector:
+    return BargeInDetector(tts_playing_fn=lambda: True, on_barge_in=_noop)
 
 
-# (a) L2 mask: silero_vad absent -> fallback, thread never started, and the
-# verdict is cached (later playback sentences read the cache, no re-failure).
-det = _detector()
-assert det.vad_status() == ("fallback", ""), det.vad_status()
-start, detail = server.app._barge_in_start_decision(det, config_enabled=True)
-assert start is False and "fallback" in detail, (start, detail)
-assert not det.running
-start, detail = server.app._barge_in_start_decision(det, config_enabled=True)
-assert start is False and "fallback" in detail, (start, detail)
-assert not det.running
-
-# (b) Degraded: silero_vad importable but model load fails. A broken install
-# must stay observable with its reason, and probe exactly once.
-broken = types.ModuleType("silero_vad")
-_load_calls = 0
-
-def _boom():
-    global _load_calls
-    _load_calls += 1
-    raise RuntimeError("simulated model load failure")
-
-broken.load_silero_vad = _boom
-sys.modules["silero_vad"] = broken
-
-det_broken = _detector()
-state, reason = det_broken.vad_status()
-assert state == "degraded" and "RuntimeError" in reason and "simulated" in reason, (state, reason)
-start, detail = server.app._barge_in_start_decision(det_broken, config_enabled=True)
-assert start is False and "degraded" in detail and "simulated" in detail, (start, detail)
-assert not det_broken.running
-assert _load_calls == 1, _load_calls
-start, detail = server.app._barge_in_start_decision(det_broken, config_enabled=True)
-assert start is False and "degraded" in detail, (start, detail)
-assert _load_calls == 1, _load_calls
-
-# (c) L3/L4 journey regression (the reviewed scenario): voice capability is
-# ready (stubbed here — this CI process has no real deps) while asr_manager
-# is still None (bootstrap not run, or idle-unloaded). The gate must pass.
-assert server.app.asr_manager is None, "precondition: manager not created"
-
-ready = types.ModuleType("silero_vad")
-_ready_load_calls = 0
-
-class _FakeModel:
-    def eval(self):
-        return self
-
-def _fake_load():
-    global _ready_load_calls
-    _ready_load_calls += 1
-    return _FakeModel()
-
-ready.load_silero_vad = _fake_load
-sys.modules["silero_vad"] = ready
-
-det_ready = _detector()
-assert det_ready.vad_status() == ("ready", ""), det_ready.vad_status()
-start, detail = server.app._barge_in_start_decision(det_ready, config_enabled=True)
-assert start is True and detail == "", (start, detail)
-assert server.app.asr_manager is None  # the manager plays no role in the gate
-
-# (d) Config switch off -> off, and no capability probe/log detail at all.
-# The counter already holds (c)'s single probe; this decision must add none.
-start, detail = server.app._barge_in_start_decision(_detector(), config_enabled=False)
-assert start is False and detail == "", (start, detail)
-assert _ready_load_calls == 1, _ready_load_calls
-
-print("L2_BARGE_IN_GATE_OK")
-"""
+async def _wait(event: threading.Event) -> None:
+    assert await asyncio.to_thread(event.wait, 5), "background operation did not complete"
 
 
-def test_barge_in_gate_disables_without_vad_tier() -> None:
+def test_missing_vad_is_probed_once_without_starting_listener() -> None:
+    probe = '''
+import asyncio
+import sys
+from unittest.mock import patch
+
+class Blocker:
+    calls = 0
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split('.')[0] in {'silero_vad', 'torch', 'torchaudio'}:
+            self.calls += 1
+            raise ModuleNotFoundError('L2 package absent', name=fullname)
+
+blocker = Blocker()
+sys.meta_path.insert(0, blocker)
+import server.app
+from asr.barge_in_detector import BargeInDetector
+
+async def noop(): pass
+async def run():
+    detector = BargeInDetector(tts_playing_fn=lambda: True, on_barge_in=noop)
+    assert detector._vad_capability is None
+    with patch.object(detector, '_run') as listen:
+        detector.start(asyncio.get_running_loop())
+        preparation = detector._preparation_thread
+        if preparation is not None:
+            await asyncio.to_thread(preparation.join, 5)
+            assert not preparation.is_alive()
+        assert detector._vad_capability == ('fallback', '')
+        calls = blocker.calls
+        assert calls > 0
+        for _ in range(5):
+            detector.start(asyncio.get_running_loop())
+        assert blocker.calls == calls
+        assert detector._preparation_thread is None
+        assert not detector.running
+        listen.assert_not_called()
+        assert server.app.asr_manager is None
+        detector.stop()
+
+asyncio.run(run())
+print('L2_BARGE_IN_OK')
+'''
     result = subprocess.run(
-        [sys.executable, "-c", _PROBE],
-        cwd=_PROJECT_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=120,
+        [sys.executable, "-c", probe], cwd=ROOT, capture_output=True,
+        text=True, timeout=60,
     )
-    assert result.returncode == 0, (
-        f"L2 barge-in gate probe failed:\n{result.stdout[-2000:]}\n{result.stderr[-2000:]}"
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "L2_BARGE_IN_OK" in result.stdout
+
+
+@pytest.mark.parametrize("error", [
+    ModuleNotFoundError("missing torch", name="torch"),
+    OSError("torch DLL cannot load"),
+])
+@pytest.mark.asyncio
+async def test_broken_dependency_is_cached_as_degraded(monkeypatch, error, caplog) -> None:
+    original_import = builtins.__import__
+    calls = []
+
+    def broken_import(name, *args, **kwargs):
+        if name == "silero_vad":
+            calls.append(name)
+            raise error
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", broken_import)
+    detector = _detector()
+    listeners = []
+    monkeypatch.setattr(detector, "_run", lambda: listeners.append(True))
+    with caplog.at_level("INFO"):
+        detector.start(asyncio.get_running_loop())
+        preparation = detector._preparation_thread
+        if preparation is not None:
+            await asyncio.to_thread(preparation.join, 5)
+            assert not preparation.is_alive()
+        assert detector._vad_capability[0] == "degraded"
+        assert "torch" in detector._vad_capability[1]
+        detector.start(asyncio.get_running_loop())
+        detector.stop()
+    assert calls == ["silero_vad"]
+    assert not listeners
+    assert len([r for r in caplog.records if "detector disabled" in r.message]) == 1
+    assert not any("detector failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_failed_model_load_is_cached(monkeypatch) -> None:
+    calls = []
+
+    def load():
+        calls.append(True)
+        raise RuntimeError("invalid model")
+
+    monkeypatch.setitem(sys.modules, "silero_vad", SimpleNamespace(load_silero_vad=load))
+    detector = _detector()
+    detector.start(asyncio.get_running_loop())
+    preparation = detector._preparation_thread
+    if preparation is not None:
+        await asyncio.to_thread(preparation.join, 5)
+        assert not preparation.is_alive()
+    assert detector._vad_capability == ("degraded", "RuntimeError: invalid model")
+    detector.start(asyncio.get_running_loop())
+    detector.stop()
+    assert calls == [True]
+    assert not detector.running
+
+
+@pytest.mark.parametrize("during_load", ["playing", "stopped", "restarted"])
+@pytest.mark.asyncio
+async def test_slow_preparation_keeps_loop_responsive_and_honors_stop(monkeypatch, during_load) -> None:
+    entered, release, listening = threading.Event(), threading.Event(), threading.Event()
+    loop = asyncio.get_running_loop()
+    loop_thread = threading.get_ident()
+    loads = []
+    model = SimpleNamespace(eval=lambda: None)
+
+    def load():
+        loads.append(threading.get_ident())
+        entered.set()
+        if not release.wait(5):
+            raise RuntimeError("test never released slow load")
+        return model
+
+    monkeypatch.setitem(sys.modules, "silero_vad", SimpleNamespace(load_silero_vad=load))
+    detector = _detector()
+
+    def listen():
+        assert detector._vad_model is model
+        listening.set()
+
+    monkeypatch.setattr(detector, "_run", listen)
+    detector.start(loop)
+    preparation = detector._preparation_thread
+    assert preparation is not None
+    try:
+        await _wait(entered)
+        tick = asyncio.Event()
+        loop.call_soon(tick.set)
+        await asyncio.wait_for(tick.wait(), 1)
+        assert not release.is_set() and not listening.is_set()
+        for _ in range(5):
+            detector.start(loop)
+        if during_load != "playing":
+            detector.stop()
+            assert preparation.is_alive() and not release.is_set()
+        if during_load == "restarted":
+            detector.start(loop)
+        release.set()
+        await asyncio.to_thread(preparation.join, 5)
+        assert not preparation.is_alive()
+        if during_load == "stopped":
+            assert not listening.is_set()
+            # A later sentence after idle may reuse the prepared model.
+            detector.start(loop)
+        await _wait(listening)
+        assert len(loads) == 1 and loads[0] != loop_thread
+    finally:
+        release.set()
+        await asyncio.to_thread(preparation.join, 5)
+        detector.stop()
+
+
+@pytest.mark.asyncio
+async def test_prepared_model_can_interrupt_first_keyboard_reply(monkeypatch) -> None:
+    from asr import barge_in_detector as module
+    from asr import mic_input_service
+    from server import app
+
+    monkeypatch.setattr(app, "asr_manager", None)
+
+    model = SimpleNamespace(eval=lambda: None)
+    loads, microphones = [], []
+    detected = asyncio.Event()
+
+    def load():
+        loads.append(True)
+        return model
+
+    class Iterator:
+        def __init__(self, prepared, **kwargs):
+            assert prepared is model
+
+        def __call__(self, audio, **kwargs):
+            return {"start": 0}
+
+    frame = SimpleNamespace(
+        audio=np.full(512, 0.1, dtype=np.float32), raw_audio=None,
+        rms=0.1, timestamp=0.0, seq=10,
     )
-    assert "L2_BARGE_IN_GATE_OK" in result.stdout
+    mic = SimpleNamespace(
+        start=lambda: microphones.append(True), mic_index=7,
+        cursor=lambda: SimpleNamespace(read=lambda **kwargs: frame),
+        mark_handoff=lambda *args, **kwargs: None,
+    )
+    monkeypatch.setitem(sys.modules, "silero_vad", SimpleNamespace(load_silero_vad=load, VADIterator=Iterator))
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(from_numpy=lambda value: value))
+    monkeypatch.setattr(mic_input_service, "get_mic_input_service", lambda: mic)
+    monkeypatch.setattr(module, "BARGE_IN_START_DELAY_MS", 0)
+
+    async def interrupt():
+        detected.set()
+
+    detector = BargeInDetector(tts_playing_fn=lambda: True, on_barge_in=interrupt)
+    monkeypatch.setattr(detector, "_collect_confirm_frames", lambda cursor, first: [first])
+    monkeypatch.setattr(detector, "_is_self_echo_candidate", lambda frames: False)
+    try:
+        for _ in range(2):
+            detector.start(asyncio.get_running_loop())
+            await asyncio.wait_for(detected.wait(), 5)
+            detector.stop()
+            detected.clear()
+        assert len(loads) == 1
+        assert len(microphones) == 2
+        assert app.asr_manager is None
+    finally:
+        detector.stop()

--- a/tests/test_barge_in_capability_gate.py
+++ b/tests/test_barge_in_capability_gate.py
@@ -3,7 +3,11 @@
 On an L2 install (silero-vad/torch absent) with barge-in config enabled, the
 startup boundary must keep the detector off with an observable degradation
 instead of spawning a thread that fails on import and emits barge_in_error on
-every sentence. The gate consumes the ASR manager's public vad_status().
+every sentence. The capability fact is owned by BargeInDetector (it loads its
+own VAD model) and must NOT be inferred from the ASRManager lifecycle: the
+manager is created lazily when ASR first listens and cleared on idle unload,
+while the detector only needs its own VAD — so keyboard-chat-then-first-
+playback and post-unload journeys must still pass the gate.
 """
 
 from __future__ import annotations
@@ -19,6 +23,7 @@ _L3_ONLY_MODULES = ("silero_vad", "torch", "torchaudio")
 
 _PROBE = f"""
 import sys
+import types
 
 _BLOCKED = {set(_L3_ONLY_MODULES)!r}
 
@@ -46,49 +51,83 @@ else:
     raise SystemExit("silero_vad unexpectedly importable under the L2 mask")
 
 import server.app
-from asr.manager import ASRManager
+from asr.barge_in_detector import BargeInDetector
 
 
-def _l2_manager():
-    # Skip __init__ (backend/mic construction); the vad capability probe is
-    # what the gate consumes and it runs synchronously inside _init_vad().
-    mgr = ASRManager.__new__(ASRManager)
-    mgr._init_vad()
-    return mgr
+async def _noop() -> None:
+    return None
 
 
-# Real L2 capability chain: masked imports -> manager reports fallback.
-mgr = _l2_manager()
-assert mgr.vad_status() == ("fallback", ""), mgr.vad_status()
-
-# Gate: config on + fallback tier -> stay off, state observable.
-start, detail = server.app._barge_in_start_decision(mgr, config_enabled=True)
-assert start is False, (start, detail)
-assert "fallback" in detail, detail
-
-# Degraded (installed but broken) must stay observable, not fake absence.
-mgr._vad_degraded = "boom"
-assert mgr.vad_status() == ("degraded", "boom"), mgr.vad_status()
-start, detail = server.app._barge_in_start_decision(mgr, config_enabled=True)
-assert start is False and "degraded" in detail and "boom" in detail, (start, detail)
-
-# No observed capability (manager not created yet) -> stay off.
-start, detail = server.app._barge_in_start_decision(None, config_enabled=True)
-assert start is False and detail, (start, detail)
+def _detector():
+    return BargeInDetector(tts_playing_fn=lambda: False, on_barge_in=_noop)
 
 
-class _ReadyManager:
-    def vad_status(self):
-        return "ready", ""
+# (a) L2 mask: silero_vad absent -> fallback, thread never started, and the
+# verdict is cached (later playback sentences read the cache, no re-failure).
+det = _detector()
+assert det.vad_status() == ("fallback", ""), det.vad_status()
+start, detail = server.app._barge_in_start_decision(det, config_enabled=True)
+assert start is False and "fallback" in detail, (start, detail)
+assert not det.running
+start, detail = server.app._barge_in_start_decision(det, config_enabled=True)
+assert start is False and "fallback" in detail, (start, detail)
+assert not det.running
 
+# (b) Degraded: silero_vad importable but model load fails. A broken install
+# must stay observable with its reason, and probe exactly once.
+broken = types.ModuleType("silero_vad")
+_load_calls = 0
 
-# Ready tier passes the gate (normal-path contract; stub: no torch here).
-start, detail = server.app._barge_in_start_decision(_ReadyManager(), config_enabled=True)
+def _boom():
+    global _load_calls
+    _load_calls += 1
+    raise RuntimeError("simulated model load failure")
+
+broken.load_silero_vad = _boom
+sys.modules["silero_vad"] = broken
+
+det_broken = _detector()
+state, reason = det_broken.vad_status()
+assert state == "degraded" and "RuntimeError" in reason and "simulated" in reason, (state, reason)
+start, detail = server.app._barge_in_start_decision(det_broken, config_enabled=True)
+assert start is False and "degraded" in detail and "simulated" in detail, (start, detail)
+assert not det_broken.running
+assert _load_calls == 1, _load_calls
+start, detail = server.app._barge_in_start_decision(det_broken, config_enabled=True)
+assert start is False and "degraded" in detail, (start, detail)
+assert _load_calls == 1, _load_calls
+
+# (c) L3/L4 journey regression (the reviewed scenario): voice capability is
+# ready (stubbed here — this CI process has no real deps) while asr_manager
+# is still None (bootstrap not run, or idle-unloaded). The gate must pass.
+assert server.app.asr_manager is None, "precondition: manager not created"
+
+ready = types.ModuleType("silero_vad")
+_ready_load_calls = 0
+
+class _FakeModel:
+    def eval(self):
+        return self
+
+def _fake_load():
+    global _ready_load_calls
+    _ready_load_calls += 1
+    return _FakeModel()
+
+ready.load_silero_vad = _fake_load
+sys.modules["silero_vad"] = ready
+
+det_ready = _detector()
+assert det_ready.vad_status() == ("ready", ""), det_ready.vad_status()
+start, detail = server.app._barge_in_start_decision(det_ready, config_enabled=True)
 assert start is True and detail == "", (start, detail)
+assert server.app.asr_manager is None  # the manager plays no role in the gate
 
-# Config switch off -> off, and callers must not log a capability detail.
-start, detail = server.app._barge_in_start_decision(_ReadyManager(), config_enabled=False)
+# (d) Config switch off -> off, and no capability probe/log detail at all.
+# The counter already holds (c)'s single probe; this decision must add none.
+start, detail = server.app._barge_in_start_decision(_detector(), config_enabled=False)
 assert start is False and detail == "", (start, detail)
+assert _ready_load_calls == 1, _ready_load_calls
 
 print("L2_BARGE_IN_GATE_OK")
 """

--- a/tests/test_barge_in_capability_gate.py
+++ b/tests/test_barge_in_capability_gate.py
@@ -1,0 +1,108 @@
+"""L2 tier contract: barge-in must not start a doomed detector thread.
+
+On an L2 install (silero-vad/torch absent) with barge-in config enabled, the
+startup boundary must keep the detector off with an observable degradation
+instead of spawning a thread that fails on import and emits barge_in_error on
+every sentence. The gate consumes the ASR manager's public vad_status().
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+# L2 = audio stack present, vad tier (silero-vad + its torch dependency) absent.
+_L3_ONLY_MODULES = ("silero_vad", "torch", "torchaudio")
+
+_PROBE = f"""
+import sys
+
+_BLOCKED = {set(_L3_ONLY_MODULES)!r}
+
+class _Blocker:
+    # Simulate a missing package for `import` statements: the finder raises
+    # ModuleNotFoundError, which is what a real L2 install raises.
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in _BLOCKED:
+            raise ModuleNotFoundError(
+                f"{{name}} is not part of the L2 install", name=name
+            )
+        return None
+
+sys.meta_path.insert(0, _Blocker())
+for mod in list(sys.modules):
+    if mod.split(".")[0] in _BLOCKED:
+        del sys.modules[mod]
+
+# Prove the mask is real: the vad tier is genuinely absent in this process.
+try:
+    import silero_vad  # noqa: F401
+except ModuleNotFoundError:
+    pass
+else:
+    raise SystemExit("silero_vad unexpectedly importable under the L2 mask")
+
+import server.app
+from asr.manager import ASRManager
+
+
+def _l2_manager():
+    # Skip __init__ (backend/mic construction); the vad capability probe is
+    # what the gate consumes and it runs synchronously inside _init_vad().
+    mgr = ASRManager.__new__(ASRManager)
+    mgr._init_vad()
+    return mgr
+
+
+# Real L2 capability chain: masked imports -> manager reports fallback.
+mgr = _l2_manager()
+assert mgr.vad_status() == ("fallback", ""), mgr.vad_status()
+
+# Gate: config on + fallback tier -> stay off, state observable.
+start, detail = server.app._barge_in_start_decision(mgr, config_enabled=True)
+assert start is False, (start, detail)
+assert "fallback" in detail, detail
+
+# Degraded (installed but broken) must stay observable, not fake absence.
+mgr._vad_degraded = "boom"
+assert mgr.vad_status() == ("degraded", "boom"), mgr.vad_status()
+start, detail = server.app._barge_in_start_decision(mgr, config_enabled=True)
+assert start is False and "degraded" in detail and "boom" in detail, (start, detail)
+
+# No observed capability (manager not created yet) -> stay off.
+start, detail = server.app._barge_in_start_decision(None, config_enabled=True)
+assert start is False and detail, (start, detail)
+
+
+class _ReadyManager:
+    def vad_status(self):
+        return "ready", ""
+
+
+# Ready tier passes the gate (normal-path contract; stub: no torch here).
+start, detail = server.app._barge_in_start_decision(_ReadyManager(), config_enabled=True)
+assert start is True and detail == "", (start, detail)
+
+# Config switch off -> off, and callers must not log a capability detail.
+start, detail = server.app._barge_in_start_decision(_ReadyManager(), config_enabled=False)
+assert start is False and detail == "", (start, detail)
+
+print("L2_BARGE_IN_GATE_OK")
+"""
+
+
+def test_barge_in_gate_disables_without_vad_tier() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        cwd=_PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"L2 barge-in gate probe failed:\n{result.stdout[-2000:]}\n{result.stderr[-2000:]}"
+    )
+    assert "L2_BARGE_IN_GATE_OK" in result.stdout

--- a/tests/test_speculative_turn.py
+++ b/tests/test_speculative_turn.py
@@ -163,7 +163,7 @@ def test_manager_on_result_callback():
     """_SpeculativeTranscription：完成且有效才回调；作废后不回调。
 
     被测对象只依赖 backend/threading/numpy（asr.manager 顶层无 torch/silero），
-    model-less CI 也必须真实执行，不得用 importorskip 假跳过。
+    model-less CI 也必须真实执行，不得以依赖跳过假覆盖。
     """
     import numpy as np
     from asr.manager import _SpeculativeTranscription

--- a/tests/test_speculative_turn.py
+++ b/tests/test_speculative_turn.py
@@ -160,10 +160,11 @@ def test_stale_slot_discarded():
 
 
 def test_manager_on_result_callback():
-    """_SpeculativeTranscription：完成且有效才回调；作废后不回调。"""
-    import pytest
+    """_SpeculativeTranscription：完成且有效才回调；作废后不回调。
 
-    pytest.importorskip("torch", reason="local-model tier (torch) is not installed")
+    被测对象只依赖 backend/threading/numpy（asr.manager 顶层无 torch/silero），
+    model-less CI 也必须真实执行，不得用 importorskip 假跳过。
+    """
     import numpy as np
     from asr.manager import _SpeculativeTranscription
 


### PR DESCRIPTION
L2 remote-voice installs without Silero VAD no longer start a failing barge-in listener on every playback sentence. `BargeInDetector` prepares and caches its own VAD once in a background thread, so cold imports/model loading cannot block the playback callback or event loop. It distinguishes missing VAD from broken dependencies/model loading and logs the unavailable result once.

A stop received during preparation cancels the pending listener start; a later sentence can reuse the same preparation/model. Keyboard-first conversations and playback after ASR idle unload continue to work without an `ASRManager` instance. The synchronous capability gate in `server/app.py` is removed; the existing configuration gate stays in place. The speculative-transcription callback test now executes in model-less CI without the unrelated Torch skip.

Validation: 37 focused tests passed, including slow-load event-loop responsiveness, stop/restart during preparation, missing/transitive/broken dependencies, model reuse, and synthetic first-playback interruption. Full-repository Ruff and all seven architecture views passed. A real Silero cold-load probe in the existing Torch 2.5.1+cu124 environment took 2.223s in the background; `start()` returned in 0.228ms, the loop callback ran at 0.335ms, and stopping during preparation did not launch the listener. This probe did not capture microphone audio. All three remote checks passed for `43f1416`.

### 中文摘要

L2 远程语音环境缺少 Silero VAD 时，不再为每个播放句启动必然报错的插话监听线程。`BargeInDetector` 在后台完成一次性 VAD 探测和加载，并缓存缺席或损坏原因；播放回调和事件循环不再承担冷加载。

准备期间收到停止会取消待启动监听，之后的新句子可以复用准备结果与模型。键盘聊天首句、ASR 空闲卸载后的播放仍可插话，不依赖 `ASRManager` 实例。移除 `server/app.py` 中的同步能力探测，保留原有配置开关；投机转写回调测试去除不相关的 Torch 跳过，在无模型 CI 中真实执行。

维护方已同步最新 main 并补齐修复。37 项定向测试、全仓 Ruff 和 7 份架构视图检查通过；真实 Silero 冷加载约 2.223 秒在后台完成，启动调用 0.228ms、事件循环回调 0.335ms，准备期间停止后未启动监听。实测未采集麦克风音频。`43f1416` 的三项远程检查已全部通过。

Closes #41
Closes #42

