### PR TITLE
fix(macos): lazy-load Windows pointer forwarding

### DIFF
--- a/tests/test_wallpaper_bridge_portability.py
+++ b/tests/test_wallpaper_bridge_portability.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Regression only affects non-Windows imports")
+def test_wallpaper_bridge_import_does_not_load_windows_pointer_api() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", "import wallpaper.wallpaper_engine_bridge"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/wallpaper/wallpaper_engine_bridge.py
+++ b/wallpaper/wallpaper_engine_bridge.py
@@ -24,11 +24,10 @@ import urllib.parse
 import urllib.request
 import webbrowser
 from pathlib import Path
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from config.asset_paths import SPRITEFORGE_RUNTIME_ROOT
 from config.settings import WALLPAPER_SFX_GATE_LOG, WALLPAPER_WHEEL_FORWARD
-from wallpaper.pointer_wheel_forwarder import PointerWheelForwarder
 from render.server import AssetServer
 from wallpaper.scene_assets import (
     _PROJECT_ROOT,
@@ -42,6 +41,9 @@ from wallpaper.scene_assets import (
     _prepare_background_asset,
     _prepare_scenario_payload,
 )
+
+if TYPE_CHECKING:
+    from wallpaper.pointer_wheel_forwarder import PointerWheelForwarder
 
 logger = logging.getLogger(__name__)
 
@@ -713,6 +715,8 @@ class WallpaperEngineBridgeHost:
         self._init_scene()
         if self._slice_host != "electron" and WALLPAPER_WHEEL_FORWARD and sys.platform == "win32":
             try:
+                from wallpaper.pointer_wheel_forwarder import PointerWheelForwarder
+
                 self._wheel_forwarder = PointerWheelForwarder(
                     lambda dx, dy: self._state.publish(
                         {"method": "pointerWheel", "args": [{"deltaX": dx, "deltaY": dy}]}


### PR DESCRIPTION
## What and why

Importing `wallpaper.wallpaper_engine_bridge` on macOS currently imports the Windows-only pointer wheel hook at module load time. That hook references `ctypes.WINFUNCTYPE`, which is unavailable on non-Windows platforms, so backend startup and test collection fail before wallpaper functionality is used.

This PR keeps the type-only import behind `TYPE_CHECKING` and loads the Windows implementation only inside the existing `sys.platform == "win32"` branch. Windows behavior is unchanged.

Linked Issue for product-semantic or public-contract changes: #47

## Change class

- [x] Routine fix, documentation, test, maintenance, or presentation-only UI
- [ ] Product-semantic or public-contract change discussed in the linked Issue
- [ ] Isolated, default-off experiment

Owning layer: `wallpaper/wallpaper_engine_bridge.py`

User-visible effect, or `none`: The wallpaper bridge and backend can be imported on macOS and Linux; Windows wheel forwarding remains available when enabled.

Compatibility or migration impact, or `none`: No configuration or migration required.

## Evidence

Commands and manual journeys run:

- `python -m pytest -q tests/test_wallpaper_bridge_portability.py tests/test_local_bridge_security.py tests/test_wallpaper_asset_revision.py tests/test_wallpaper_bridge_observability.py` — 16 passed
- `python -m ruff check wallpaper/wallpaper_engine_bridge.py tests/test_wallpaper_bridge_portability.py` — passed
- `git diff --check` — passed

- [x] Relevant Python tests pass
- [x] CPU/model-less baseline remains supported
- [ ] Electron `npm run build` passes when Electron code changed
- [ ] Dependency audit passes when dependencies changed
- [ ] Before/after screenshots are attached for visible UI changes
- [ ] Documentation/examples are updated for changed settings or contracts

## Final check

- [x] This PR addresses one coherent problem without unrelated cleanup
- [x] It does not add a speculative API, fallback, or compatibility path
- [x] No secrets, local state, model weights, voice material, or restricted assets are included
- [x] Third-party notices and provenance are preserved
