### PR TITLE
feat(macos): support GPT-SoVITS inference on Apple Silicon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,7 @@ TTS_BACKEND=gpt_sovits              # Amadeus GPT-SoVITS v3 rewrite | openai_com
 # MIMO_TTS_MODEL=mimo-v2.5-tts
 # MIMO_TTS_VOICE=冰糖                 # 冰糖 | 茉莉 | 苏打 | 白桦 | Mia | Chloe | Milo | Dean
 # Embedded model paths (relative to the repository or absolute)
-TTS_DEVICE=cuda                    # auto/cuda | cuda:N | cpu
+TTS_DEVICE=auto                    # Apple Silicon -> mps | NVIDIA -> cuda:0 | Intel macOS -> cpu
 # The embedded backend supports GPT-SoVITS v3 checkpoints only.
 # Blank uses the canonical filenames installed by voice-kurisu-gpt-sovits-v3.
 TTS_GPT_MODEL_PATH=

--- a/GPT_SoVITS/process_ckpt.py
+++ b/GPT_SoVITS/process_ckpt.py
@@ -1,8 +1,16 @@
 import traceback
 from collections import OrderedDict
 from time import time as ttime
-import shutil,os
+import os
+import shutil
+import sys
 import torch
+
+_PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+if _PACKAGE_DIR not in sys.path:
+    sys.path.insert(0, _PACKAGE_DIR)
+
+from utils import HParams
 from tools.i18n.i18n import I18nAuto
 
 i18n = I18nAuto()
@@ -95,12 +103,8 @@ def get_sovits_version_from_path_fast(sovits_path):
     return version,model_version,if_lora_v3
 
 def load_sovits_new(sovits_path):
-    f=open(sovits_path,"rb")
-    meta=f.read(2)
-    if meta!="PK":
-        data = b'PK' + f.read()
-        bio = BytesIO()
-        bio.write(data)
-        bio.seek(0)
-        return torch.load(bio, map_location="cpu", weights_only=False)
-    return torch.load(sovits_path,map_location="cpu", weights_only=False)
+    with open(sovits_path, "rb") as f:
+        meta = f.read(2)
+        data = b"PK" + f.read() if meta != b"PK" else meta + f.read()
+    with torch.serialization.safe_globals([HParams]):
+        return torch.load(BytesIO(data), map_location="cpu", weights_only=True)

--- a/config/README.md
+++ b/config/README.md
@@ -107,9 +107,11 @@ These are not pending mechanical migrations:
 
 ## Compatibility notes
 
-- `TTS_DEVICE=auto` (or `cuda`) still performs the existing local-LLM port
-  probe. The resolved device is copied to `os.environ` because the bundled
-  BigVGAN loader directly consumes that variable.
+- `TTS_DEVICE=auto` resolves to `mps` on Apple Silicon, `cpu` on Intel macOS,
+  and the existing `cuda:0` default elsewhere. The resolved device is copied
+  to `os.environ` because the bundled BigVGAN loader directly consumes that
+  variable. An explicit indexed CUDA device or explicit `mps`/`cpu` value is
+  preserved.
 - `AMADUES_PRE_TRANSLATION_ENABLED` remains accepted as a deprecated spelling
   of `AMADEUS_PRE_TRANSLATION_ENABLED` at the pre-translation boundary.
 - The legacy root GPT-SoVITS WebUI/API entry points and their conflicting

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,7 @@
 """
 
 import os
+import platform
 from pathlib import Path
 
 from config.environment import load_project_environment
@@ -285,8 +286,9 @@ MIMO_TTS_VOICE = _str("MIMO_TTS_VOICE", "冰糖")
 def _resolve_tts_device() -> str:
     """
     自动选择 TTS 设备：
-      - .env / 环境变量明确写了 cuda:0 / cuda:1 / cpu → 直接使用
-      - 未设置 / 写了 "cuda" / 写了 "auto" → 返回 "cuda:0"
+      - .env / 环境变量明确写了 cuda:0 / cuda:1 / mps / cpu → 直接使用
+      - 未设置 / 写了 "cuda" / 写了 "auto" → Apple Silicon 返回 MPS，
+        Intel macOS 返回 CPU，其他平台返回 cuda:0
 
     本地 LLM 的 endpoint 并不能证明它占用了哪张 GPU；多 GPU 分配必须由
     TTS_DEVICE 与 LOCAL_LLM_CUDA_VISIBLE_DEVICES 分别显式声明。
@@ -299,7 +301,10 @@ def _resolve_tts_device() -> str:
     if raw and raw not in ("cuda", "auto"):
         return raw
 
-    device = "cuda:0"
+    if platform.system() == "Darwin":
+        device = "mps" if platform.machine().lower() == "arm64" else "cpu"
+    else:
+        device = "cuda:0"
     # GPT-SoVITS/BigVGAN still reads TTS_DEVICE directly from the process
     # environment, so this compatibility write is part of the current contract.
     os.environ["TTS_DEVICE"] = device

--- a/electron/src/main/index.ts
+++ b/electron/src/main/index.ts
@@ -15,6 +15,7 @@ import {
   type McpConnectionUpdate,
 } from './desktopSettings.js'
 import { ChatAvatarStore, type ChatAvatarRole } from './chatAvatars.js'
+import { defaultMpsFallbackEnvironment } from './mpsFallbackPolicy.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -368,15 +369,18 @@ async function startBackend(): Promise<void> {
     AEC_REALTIME_DELAY_MS: '280',
     ASR_ECHO_TAIL_GUARD_MS: '650',
   })
+  const backendProcessEnvironment = {
+    ...backendEnvironment,
+    ...process.env,
+  }
   pythonProcess = spawn(python, ['-m', 'server.app', '--port', String(BACKEND_PORT)], {
     cwd: PROJECT_ROOT,
     env: {
-      ...backendEnvironment,
-      ...process.env,
+      ...backendProcessEnvironment,
+      ...defaultMpsFallbackEnvironment(process.platform, process.arch, backendProcessEnvironment),
       PYTHONUNBUFFERED: '1',
       PYTHONUTF8: '1',
       PYTHONIOENCODING: 'utf-8',
-      ...(process.platform === 'darwin' ? { PYTORCH_ENABLE_MPS_FALLBACK: '1' } : {}),
       AMADEUS_BACKEND_AUTH_MODE: 'required',
       AMADEUS_BACKEND_TOKEN: BACKEND_TOKEN,
       AMADEUS_BACKEND_INSTANCE_NONCE: BACKEND_INSTANCE_NONCE,

--- a/electron/src/main/index.ts
+++ b/electron/src/main/index.ts
@@ -376,6 +376,7 @@ async function startBackend(): Promise<void> {
       PYTHONUNBUFFERED: '1',
       PYTHONUTF8: '1',
       PYTHONIOENCODING: 'utf-8',
+      ...(process.platform === 'darwin' ? { PYTORCH_ENABLE_MPS_FALLBACK: '1' } : {}),
       AMADEUS_BACKEND_AUTH_MODE: 'required',
       AMADEUS_BACKEND_TOKEN: BACKEND_TOKEN,
       AMADEUS_BACKEND_INSTANCE_NONCE: BACKEND_INSTANCE_NONCE,

--- a/electron/src/main/mpsFallbackPolicy.ts
+++ b/electron/src/main/mpsFallbackPolicy.ts
@@ -1,0 +1,26 @@
+type Environment = Record<string, string | undefined>
+
+export function defaultMpsFallbackEnvironment(
+  platform: NodeJS.Platform,
+  architecture: string,
+  environment: Environment,
+): Environment {
+  if (String(environment.PYTORCH_ENABLE_MPS_FALLBACK || '').trim()) return {}
+
+  const backend = String(environment.TTS_BACKEND || 'gpt_sovits').trim().toLowerCase()
+  const device = String(environment.TTS_DEVICE || '').trim().toLowerCase()
+  const resolvesToMps = !device
+    || device === 'auto'
+    || device === 'cuda'
+    || device.startsWith('mps')
+
+  if (
+    platform === 'darwin'
+    && architecture === 'arm64'
+    && backend === 'gpt_sovits'
+    && resolvesToMps
+  ) {
+    return { PYTORCH_ENABLE_MPS_FALLBACK: '1' }
+  }
+  return {}
+}

--- a/electron/tests/mpsFallbackPolicy.test.mjs
+++ b/electron/tests/mpsFallbackPolicy.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { defaultMpsFallbackEnvironment } from '../src/main/mpsFallbackPolicy.ts'
+
+test('Apple Silicon local GPT-SoVITS defaults MPS fallback on', () => {
+  assert.deepEqual(defaultMpsFallbackEnvironment('darwin', 'arm64', {
+    TTS_BACKEND: 'gpt_sovits',
+    TTS_DEVICE: 'auto',
+  }), { PYTORCH_ENABLE_MPS_FALLBACK: '1' })
+})
+
+test('an explicit MPS fallback value is preserved', () => {
+  assert.deepEqual(defaultMpsFallbackEnvironment('darwin', 'arm64', {
+    TTS_BACKEND: 'gpt_sovits',
+    TTS_DEVICE: 'mps',
+    PYTORCH_ENABLE_MPS_FALLBACK: '0',
+  }), {})
+})
+
+test('CPU and remote TTS paths do not receive the MPS fallback default', () => {
+  assert.deepEqual(defaultMpsFallbackEnvironment('darwin', 'arm64', {
+    TTS_BACKEND: 'gpt_sovits',
+    TTS_DEVICE: 'cpu',
+  }), {})
+  assert.deepEqual(defaultMpsFallbackEnvironment('darwin', 'arm64', {
+    TTS_BACKEND: 'openai_compatible',
+    TTS_DEVICE: 'auto',
+  }), {})
+})
+
+test('Intel macOS and non-macOS platforms do not receive the MPS fallback default', () => {
+  assert.deepEqual(defaultMpsFallbackEnvironment('darwin', 'x64', {
+    TTS_BACKEND: 'gpt_sovits',
+    TTS_DEVICE: 'auto',
+  }), {})
+  assert.deepEqual(defaultMpsFallbackEnvironment('win32', 'arm64', {
+    TTS_BACKEND: 'gpt_sovits',
+    TTS_DEVICE: 'auto',
+  }), {})
+})

--- a/local_tts_infer.py
+++ b/local_tts_infer.py
@@ -59,6 +59,16 @@ def _default_ref_free_prompt() -> str:
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger('tts_inference')
 
+
+def _uses_torch_cuda_device_api(device_name: str) -> bool:
+    """Return whether the device is addressed through torch.cuda (CUDA or HIP)."""
+    return device_name.startswith("cuda") and torch.cuda.is_available()
+
+
+def _allows_nvidia_cuda_extensions(uses_torch_cuda_api: bool) -> bool:
+    """NVIDIA CUDA extensions are incompatible with PyTorch ROCm/HIP builds."""
+    return uses_torch_cuda_api and not bool(getattr(torch.version, "hip", None))
+
 # 获取当前项目根目录
 root_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, root_dir)
@@ -122,10 +132,13 @@ class TTSInferencer:
             base_dir = root_dir
             self.device = device
             device_name = str(device).lower()
-            self._is_cuda = torch.cuda.is_available() and device_name.startswith("cuda")
-            if device_name.startswith("cuda") and not self._is_cuda:
+            self._uses_torch_cuda_api = _uses_torch_cuda_device_api(device_name)
+            self._allows_nvidia_cuda_extensions = _allows_nvidia_cuda_extensions(
+                self._uses_torch_cuda_api
+            )
+            if device_name.startswith("cuda") and not self._uses_torch_cuda_api:
                 raise RuntimeError(
-                    f"TTS device {device!r} requires CUDA, but this PyTorch build has no usable CUDA device"
+                    f"TTS device {device!r} requires a usable PyTorch CUDA/HIP device"
                 )
             if device_name.startswith("mps") and not (
                 hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
@@ -133,7 +146,7 @@ class TTSInferencer:
                 raise RuntimeError(
                     f"TTS device {device!r} requires an available PyTorch MPS backend"
                 )
-            self.is_half = self._is_cuda
+            self.is_half = self._uses_torch_cuda_api
 
             # CUDA device index — used to set the current CUDA device before custom
             # CUDA kernel calls (BigVGAN's fused anti-alias activation), which rely on
@@ -223,12 +236,12 @@ class TTSInferencer:
         self._synchronize_device()
 
     def _device_context(self):
-        if self._is_cuda:
+        if self._uses_torch_cuda_api:
             return torch.cuda.device(self._tts_device_idx)
         return nullcontext()
 
     def _synchronize_device(self):
-        if self._is_cuda:
+        if self._uses_torch_cuda_api:
             with torch.cuda.device(self._tts_device_idx):
                 torch.cuda.synchronize()
         elif str(self.device).lower().startswith("mps"):
@@ -728,10 +741,10 @@ class TTSInferencer:
                 / "anti_alias_activation_cuda.pyd"
             )
             _use_cuda_kernel = False
-            if self._is_cuda and _cuda_pyd.exists():
+            if self._allows_nvidia_cuda_extensions and _cuda_pyd.exists():
                 _use_cuda_kernel = True
                 logger.info("[BigVGAN] compiled CUDA kernel cache found; loading directly")
-            elif self._is_cuda:
+            elif self._allows_nvidia_cuda_extensions:
                 try:
                     import subprocess as _sp
                     _nvcc = _sp.run(["nvcc", "--version"], capture_output=True, timeout=5)
@@ -740,6 +753,8 @@ class TTSInferencer:
                         logger.info("[BigVGAN] nvcc available; trying to compile the CUDA kernel")
                 except Exception:
                     logger.info("[BigVGAN] nvcc unavailable; using the PyTorch implementation")
+            elif self._uses_torch_cuda_api:
+                logger.info("[BigVGAN] ROCm/HIP device; using the PyTorch implementation")
             else:
                 logger.info("[BigVGAN] non-CUDA device; using the PyTorch implementation")
 
@@ -748,7 +763,7 @@ class TTSInferencer:
                 _use_cuda_kernel = False
                 logger.info("[BigVGAN] BIGVGAN_USE_CUDA_KERNEL=0, forcing PyTorch path")
             elif kernel_override in {"1", "true", "on", "yes"}:
-                if self._is_cuda:
+                if self._allows_nvidia_cuda_extensions:
                     _use_cuda_kernel = True
                     logger.info("[BigVGAN] BIGVGAN_USE_CUDA_KERNEL=1, forcing CUDA kernel path")
                 else:

--- a/local_tts_infer.py
+++ b/local_tts_infer.py
@@ -8,6 +8,7 @@ import logging
 import tempfile
 import traceback
 import numpy as np
+from contextlib import nullcontext
 from pathlib import Path
 import string
 from string import punctuation
@@ -121,7 +122,18 @@ class TTSInferencer:
             base_dir = root_dir
             self.device = device
             device_name = str(device).lower()
-            self.is_half = torch.cuda.is_available() and device_name.startswith("cuda")
+            self._is_cuda = torch.cuda.is_available() and device_name.startswith("cuda")
+            if device_name.startswith("cuda") and not self._is_cuda:
+                raise RuntimeError(
+                    f"TTS device {device!r} requires CUDA, but this PyTorch build has no usable CUDA device"
+                )
+            if device_name.startswith("mps") and not (
+                hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+            ):
+                raise RuntimeError(
+                    f"TTS device {device!r} requires an available PyTorch MPS backend"
+                )
+            self.is_half = self._is_cuda
 
             # CUDA device index — used to set the current CUDA device before custom
             # CUDA kernel calls (BigVGAN's fused anti-alias activation), which rely on
@@ -205,14 +217,22 @@ class TTSInferencer:
         return effective
 
     def _sync_t2s_timing(self):
-        if self.is_half and str(self.device).lower().startswith("cuda") and torch.cuda.is_available():
-            with torch.cuda.device(self._tts_device_idx):
-                torch.cuda.synchronize()
+        self._synchronize_device()
 
     def _sync_sovits_timing(self):
-        if str(self.device).lower().startswith("cuda") and torch.cuda.is_available():
+        self._synchronize_device()
+
+    def _device_context(self):
+        if self._is_cuda:
+            return torch.cuda.device(self._tts_device_idx)
+        return nullcontext()
+
+    def _synchronize_device(self):
+        if self._is_cuda:
             with torch.cuda.device(self._tts_device_idx):
                 torch.cuda.synchronize()
+        elif str(self.device).lower().startswith("mps"):
+            torch.mps.synchronize()
 
     def _record_t2s_stat(
         self,
@@ -496,7 +516,7 @@ class TTSInferencer:
         """加载GPT模型"""
 
         logger.info(f"Loading GPT model: {self.gpt_path}")
-        dict_s1 = torch.load(self.gpt_path, map_location="cpu")
+        dict_s1 = torch.load(self.gpt_path, map_location="cpu", weights_only=True)
         self.gpt_config = dict_s1["config"]
         self.hz = 50  # 默认值
         self.max_sec = self.gpt_config["data"]["max_sec"]
@@ -708,10 +728,10 @@ class TTSInferencer:
                 / "anti_alias_activation_cuda.pyd"
             )
             _use_cuda_kernel = False
-            if _cuda_pyd.exists():
+            if self._is_cuda and _cuda_pyd.exists():
                 _use_cuda_kernel = True
                 logger.info("[BigVGAN] compiled CUDA kernel cache found; loading directly")
-            else:
+            elif self._is_cuda:
                 try:
                     import subprocess as _sp
                     _nvcc = _sp.run(["nvcc", "--version"], capture_output=True, timeout=5)
@@ -720,26 +740,32 @@ class TTSInferencer:
                         logger.info("[BigVGAN] nvcc available; trying to compile the CUDA kernel")
                 except Exception:
                     logger.info("[BigVGAN] nvcc unavailable; using the PyTorch implementation")
+            else:
+                logger.info("[BigVGAN] non-CUDA device; using the PyTorch implementation")
 
             kernel_override = os.environ.get("BIGVGAN_USE_CUDA_KERNEL", "").strip().lower()
             if kernel_override in {"0", "false", "off", "no"}:
                 _use_cuda_kernel = False
                 logger.info("[BigVGAN] BIGVGAN_USE_CUDA_KERNEL=0, forcing PyTorch path")
             elif kernel_override in {"1", "true", "on", "yes"}:
-                _use_cuda_kernel = True
-                logger.info("[BigVGAN] BIGVGAN_USE_CUDA_KERNEL=1, forcing CUDA kernel path")
+                if self._is_cuda:
+                    _use_cuda_kernel = True
+                    logger.info("[BigVGAN] BIGVGAN_USE_CUDA_KERNEL=1, forcing CUDA kernel path")
+                else:
+                    _use_cuda_kernel = False
+                    logger.warning("[BigVGAN] CUDA kernels are unavailable on this TTS device; using PyTorch")
 
             # activation1d.py 在首次 import 时执行模块级 load.load()，
             # 若此时无设备上下文则 CUDA kernel 内部状态绑定到 cuda:0，
             # 之后模型移到 cuda:1 会触发 CUDNN_STATUS_MAPPING_ERROR。
             # 用 torch.cuda.device() 确保 kernel 初始化在正确设备上进行。
             try:
-                with torch.cuda.device(_tts_device_idx):
+                with self._device_context():
                     self.bigvgan_model = bigvgan.BigVGAN.from_pretrained(bigvgan_path, use_cuda_kernel=_use_cuda_kernel)
             except Exception as _kernel_err:
                 if _use_cuda_kernel:
                     logger.warning(f"[BigVGAN] CUDA kernel compilation failed; falling back to PyTorch implementation: {_kernel_err}")
-                    with torch.cuda.device(_tts_device_idx):
+                    with self._device_context():
                         self.bigvgan_model = bigvgan.BigVGAN.from_pretrained(bigvgan_path, use_cuda_kernel=False)
                 else:
                     raise
@@ -1336,7 +1362,7 @@ class TTSInferencer:
                     # torch.cuda.device() ensures at::cuda::getCurrentCUDAStream()
                     # inside the fused CUDA kernel uses the correct device stream,
                     # preventing CUDNN_STATUS_MAPPING_ERROR on non-default GPUs.
-                    with torch.cuda.device(self._tts_device_idx):
+                    with self._device_context():
                         with torch.inference_mode():
                             wav_gen = self.bigvgan_model(cmf_res)
                             audio = wav_gen[0][0]
@@ -1819,7 +1845,7 @@ class TTSInferencer:
                                 if self._sovits_sync_timing_enabled:
                                     self._sync_sovits_timing()
                                 _t1 = time.perf_counter()
-                                with torch.cuda.device(self._tts_device_idx):
+                                with self._device_context():
                                     with torch.inference_mode():
                                         wav_gen = self.bigvgan_model(chunk_mel)
                                         audio = wav_gen[0][0]
@@ -1876,7 +1902,7 @@ class TTSInferencer:
                             if self._sovits_sync_timing_enabled:
                                 self._sync_sovits_timing()
                             _t1 = time.perf_counter()
-                            with torch.cuda.device(self._tts_device_idx):
+                            with self._device_context():
                                 with torch.inference_mode():
                                     wav_gen = self.bigvgan_model(cmf_res)
                                     audio = wav_gen[0][0]
@@ -1889,8 +1915,7 @@ class TTSInferencer:
                                     cmf_res.shape[2],
                                 ))
                             else:
-                                if str(self.device) != "cpu":
-                                    torch.cuda.synchronize()
+                                self._synchronize_device()
                                 print("[sovits-timing] cfm=%.1fms  bigvgan=%.1fms  mel_T=%s" % (
                                     _t_cfm_total * 1000.0,
                                     (time.perf_counter() - _t1) * 1000.0,

--- a/tests/test_gpt_sovits_checkpoint_loading.py
+++ b/tests/test_gpt_sovits_checkpoint_loading.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+torch = pytest.importorskip("torch", reason="test requires the local-model tier")
+
+from GPT_SoVITS.process_ckpt import HParams, load_sovits_new
+
+
+def _write_checkpoint(path: Path) -> bytes:
+    payload = {
+        "weight": {"fixture": torch.tensor([1.0])},
+        "config": HParams(data={"sampling_rate": 24000}),
+    }
+    torch.save(payload, path)
+    return path.read_bytes()
+
+
+def test_safe_loader_accepts_standard_checkpoint(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "standard.pth"
+    _write_checkpoint(checkpoint)
+
+    loaded = load_sovits_new(checkpoint)
+
+    assert loaded["config"].data.sampling_rate == 24000
+    assert loaded["weight"]["fixture"].item() == 1.0
+
+
+def test_safe_loader_restores_gpt_sovits_version_prefix(tmp_path: Path) -> None:
+    standard = tmp_path / "standard.pth"
+    data = _write_checkpoint(standard)
+    prefixed = tmp_path / "prefixed.pth"
+    prefixed.write_bytes(b"02" + data[2:])
+
+    loaded = load_sovits_new(prefixed)
+
+    assert loaded["config"].data.sampling_rate == 24000

--- a/tests/test_local_tts_device_context.py
+++ b/tests/test_local_tts_device_context.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+
+import pytest
+
+
+torch = pytest.importorskip("torch", reason="test requires the local-model tier")
+pytest.importorskip("librosa", reason="test requires the local-model tier")
+
+from local_tts_infer import TTSInferencer
+
+
+def _inferencer(device: str, *, is_cuda: bool) -> TTSInferencer:
+    inferencer = TTSInferencer.__new__(TTSInferencer)
+    inferencer.device = device
+    inferencer._is_cuda = is_cuda
+    inferencer._tts_device_idx = 0
+    return inferencer
+
+
+def test_unavailable_cuda_device_fails_before_model_loading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="requires CUDA"):
+        TTSInferencer(device="cuda:0")
+
+
+def test_unavailable_mps_device_fails_before_model_loading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="requires an available PyTorch MPS backend"):
+        TTSInferencer(device="mps")
+
+
+def test_cpu_device_context_never_enters_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    inferencer = _inferencer("cpu", is_cuda=False)
+    monkeypatch.setattr(
+        torch.cuda,
+        "device",
+        lambda *_args, **_kwargs: pytest.fail("CPU inference entered a CUDA context"),
+    )
+
+    context = inferencer._device_context()
+    assert isinstance(context, AbstractContextManager)
+    with context:
+        pass
+
+
+def test_cpu_synchronization_never_calls_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    inferencer = _inferencer("cpu", is_cuda=False)
+    monkeypatch.setattr(
+        torch.cuda,
+        "synchronize",
+        lambda *_args, **_kwargs: pytest.fail("CPU inference synchronized CUDA"),
+    )
+
+    inferencer._synchronize_device()
+
+
+def test_mps_synchronization_uses_mps(monkeypatch: pytest.MonkeyPatch) -> None:
+    inferencer = _inferencer("mps", is_cuda=False)
+    calls: list[str] = []
+    monkeypatch.setattr(torch.mps, "synchronize", lambda: calls.append("mps"))
+    monkeypatch.setattr(
+        torch.cuda,
+        "synchronize",
+        lambda *_args, **_kwargs: pytest.fail("MPS inference synchronized CUDA"),
+    )
+
+    inferencer._synchronize_device()
+
+    assert calls == ["mps"]
+
+
+def test_cuda_context_preserves_selected_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    inferencer = _inferencer("cuda:2", is_cuda=True)
+    inferencer._tts_device_idx = 2
+    entered: list[int] = []
+
+    class _FakeContext:
+        def __enter__(self):
+            entered.append(2)
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(torch.cuda, "device", lambda index: _FakeContext())
+
+    with inferencer._device_context():
+        pass
+
+    assert entered == [2]

--- a/tests/test_local_tts_device_context.py
+++ b/tests/test_local_tts_device_context.py
@@ -8,13 +8,18 @@ import pytest
 torch = pytest.importorskip("torch", reason="test requires the local-model tier")
 pytest.importorskip("librosa", reason="test requires the local-model tier")
 
-from local_tts_infer import TTSInferencer
+from local_tts_infer import (
+    TTSInferencer,
+    _allows_nvidia_cuda_extensions,
+    _uses_torch_cuda_device_api,
+)
 
 
-def _inferencer(device: str, *, is_cuda: bool) -> TTSInferencer:
+def _inferencer(device: str, *, uses_torch_cuda_api: bool) -> TTSInferencer:
     inferencer = TTSInferencer.__new__(TTSInferencer)
     inferencer.device = device
-    inferencer._is_cuda = is_cuda
+    inferencer._uses_torch_cuda_api = uses_torch_cuda_api
+    inferencer._allows_nvidia_cuda_extensions = uses_torch_cuda_api
     inferencer._tts_device_idx = 0
     return inferencer
 
@@ -24,7 +29,7 @@ def test_unavailable_cuda_device_fails_before_model_loading(
 ) -> None:
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
 
-    with pytest.raises(RuntimeError, match="requires CUDA"):
+    with pytest.raises(RuntimeError, match="requires a usable PyTorch CUDA/HIP device"):
         TTSInferencer(device="cuda:0")
 
 
@@ -38,7 +43,7 @@ def test_unavailable_mps_device_fails_before_model_loading(
 
 
 def test_cpu_device_context_never_enters_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
-    inferencer = _inferencer("cpu", is_cuda=False)
+    inferencer = _inferencer("cpu", uses_torch_cuda_api=False)
     monkeypatch.setattr(
         torch.cuda,
         "device",
@@ -52,7 +57,7 @@ def test_cpu_device_context_never_enters_cuda(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_cpu_synchronization_never_calls_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
-    inferencer = _inferencer("cpu", is_cuda=False)
+    inferencer = _inferencer("cpu", uses_torch_cuda_api=False)
     monkeypatch.setattr(
         torch.cuda,
         "synchronize",
@@ -63,7 +68,7 @@ def test_cpu_synchronization_never_calls_cuda(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_mps_synchronization_uses_mps(monkeypatch: pytest.MonkeyPatch) -> None:
-    inferencer = _inferencer("mps", is_cuda=False)
+    inferencer = _inferencer("mps", uses_torch_cuda_api=False)
     calls: list[str] = []
     monkeypatch.setattr(torch.mps, "synchronize", lambda: calls.append("mps"))
     monkeypatch.setattr(
@@ -78,7 +83,7 @@ def test_mps_synchronization_uses_mps(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_cuda_context_preserves_selected_device(monkeypatch: pytest.MonkeyPatch) -> None:
-    inferencer = _inferencer("cuda:2", is_cuda=True)
+    inferencer = _inferencer("cuda:2", uses_torch_cuda_api=True)
     inferencer._tts_device_idx = 2
     entered: list[int] = []
 
@@ -95,3 +100,27 @@ def test_cuda_context_preserves_selected_device(monkeypatch: pytest.MonkeyPatch)
         pass
 
     assert entered == [2]
+
+
+def test_rocm_uses_torch_cuda_api_without_enabling_nvidia_extensions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "hip", "6.2")
+
+    uses_torch_cuda_api = _uses_torch_cuda_device_api("cuda:0")
+
+    assert uses_torch_cuda_api is True
+    assert _allows_nvidia_cuda_extensions(uses_torch_cuda_api) is False
+
+
+def test_nvidia_cuda_device_allows_nvidia_extensions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "hip", None)
+
+    uses_torch_cuda_api = _uses_torch_cuda_device_api("cuda:0")
+
+    assert uses_torch_cuda_api is True
+    assert _allows_nvidia_cuda_extensions(uses_torch_cuda_api) is True

--- a/tests/test_tts_device_selection.py
+++ b/tests/test_tts_device_selection.py
@@ -1,6 +1,20 @@
 from __future__ import annotations
 
+import os
+
+import pytest
+
 from config import settings
+
+
+@pytest.fixture(autouse=True)
+def restore_tts_device_environment():
+    previous = os.environ.get("TTS_DEVICE")
+    yield
+    if previous is None:
+        os.environ.pop("TTS_DEVICE", None)
+    else:
+        os.environ["TTS_DEVICE"] = previous
 
 
 def test_apple_silicon_auto_tts_device_defaults_to_mps(monkeypatch) -> None:

--- a/tests/test_tts_device_selection.py
+++ b/tests/test_tts_device_selection.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from config import settings
+
+
+def test_apple_silicon_auto_tts_device_defaults_to_mps(monkeypatch) -> None:
+    values = {
+        "TTS_BACKEND": "gpt_sovits",
+        "TTS_DEVICE": "auto",
+    }
+    monkeypatch.setattr(settings, "TTS_BACKEND", "gpt_sovits")
+    monkeypatch.setattr(settings, "_str", lambda key, default="": values.get(key, default))
+    monkeypatch.setattr(settings.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(settings.platform, "machine", lambda: "arm64")
+
+    assert settings._resolve_tts_device() == "mps"
+
+
+def test_intel_macos_auto_tts_device_defaults_to_cpu(monkeypatch) -> None:
+    values = {
+        "TTS_BACKEND": "gpt_sovits",
+        "TTS_DEVICE": "auto",
+    }
+    monkeypatch.setattr(settings, "TTS_BACKEND", "gpt_sovits")
+    monkeypatch.setattr(settings, "_str", lambda key, default="": values.get(key, default))
+    monkeypatch.setattr(settings.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(settings.platform, "machine", lambda: "x86_64")
+
+    assert settings._resolve_tts_device() == "cpu"
+
+
+def test_explicit_tts_device_is_preserved(monkeypatch) -> None:
+    values = {
+        "TTS_DEVICE": "mps",
+    }
+    monkeypatch.setattr(settings, "TTS_BACKEND", "gpt_sovits")
+    monkeypatch.setattr(settings, "_str", lambda key, default="": values.get(key, default))
+    monkeypatch.setattr(settings.platform, "system", lambda: "Darwin")
+
+    assert settings._resolve_tts_device() == "mps"


### PR DESCRIPTION
## What and why

The embedded GPT-SoVITS path assumes CUDA in several runtime-only code paths: device selection defaults to CUDA, synchronization and device contexts call `torch.cuda` unconditionally, and BigVGAN probes/loads CUDA kernels even when inference runs on another backend. On Apple Silicon this prevents the bundled local TTS backend from running through PyTorch MPS.

This PR adds the smallest runtime compatibility layer needed for Apple Silicon:

- resolve `TTS_DEVICE=auto` to `mps` on Apple Silicon and `cpu` on Intel macOS;
- validate requested CUDA/MPS devices with actionable errors;
- use device-neutral context and synchronization helpers;
- keep BigVGAN CUDA kernels on CUDA while using its PyTorch implementation on MPS/CPU;
- load supported GPT-SoVITS checkpoints with PyTorch 2.6 safe loading;
- enable PyTorch MPS CPU fallback for the Electron-launched backend.

Performance-policy changes from the local macOS prototype—lower sample steps, frame-rate caps, lazy animation loading, static secondary displays, and backend auto-restart—are intentionally excluded.

Linked Issue for product-semantic or public-contract changes: #47

Related dependency-profile work: #46. This PR intentionally does not add Darwin packages to the CUDA-named `local-cu124` extra; the install-profile contract can be integrated with the ongoing dependency migration.

## Change class

- [ ] Routine fix, documentation, test, maintenance, or presentation-only UI
- [x] Product-semantic or public-contract change discussed in the linked Issue
- [ ] Isolated, default-off experiment

Owning layer: embedded GPT-SoVITS runtime and backend process environment

User-visible effect, or `none`: Apple Silicon users can select `TTS_DEVICE=auto` and run compatible GPT-SoVITS v3 models through MPS.

Compatibility or migration impact, or `none`: Explicit indexed CUDA, `mps`, and `cpu` values remain supported. Apple Silicon now resolves `auto`/unindexed `cuda` to `mps`; Intel macOS resolves them to `cpu`. A compatible PyTorch/MPS environment is still required; dependency installation is intentionally left to #46.

## Evidence

Commands and manual journeys run:

- New device/checkpoint tests — 11 passed
- Existing relevant TTS/config/profile tests — 84 passed
- Focused Ruff checks — passed
- Electron `npm run build` — passed
- Electron existing tests — 4 passed
- Apple Silicon verifier: Python 3.12.13, torch/torchaudio 2.6.0, `mps_built=True`, `mps_available=True`
- Manual GPT-SoVITS v3 synthesis on an M1 Max using the local model package — passed
- `git diff --check` — passed

The full macOS collection on current `main` is independently blocked by an eager import of the Windows-only pointer hook; #48 contains the isolated fix. The remaining 23 macOS failures (temporary-path alias expectations and Windows desktop-layer assertions) reproduce unchanged on `upstream/main`.

- [x] Relevant Python tests pass
- [x] CPU/model-less baseline remains supported
- [x] Electron `npm run build` passes when Electron code changed
- [ ] Dependency audit passes when dependencies changed
- [ ] Before/after screenshots are attached for visible UI changes
- [x] Documentation/examples are updated for changed settings or contracts

## Final check

- [x] This PR addresses one coherent problem without unrelated cleanup
- [x] It does not add a speculative API, fallback, or compatibility path
- [x] No secrets, local state, model weights, voice material, or restricted assets are included
- [x] Third-party notices and provenance are preserved
