### PR TITLE
fix(macos): preserve native clipboard shortcuts

### DIFF
--- a/electron/src/main/applicationMenu.ts
+++ b/electron/src/main/applicationMenu.ts
@@ -1,0 +1,12 @@
+import type { MenuItemConstructorOptions } from 'electron'
+
+export function applicationMenuTemplate(
+  platform: NodeJS.Platform,
+): MenuItemConstructorOptions[] | null {
+  if (platform !== 'darwin') return null
+
+  return [
+    { role: 'appMenu' },
+    { role: 'editMenu' },
+  ]
+}

--- a/electron/src/main/index.ts
+++ b/electron/src/main/index.ts
@@ -15,6 +15,7 @@ import {
   type McpConnectionUpdate,
 } from './desktopSettings.js'
 import { ChatAvatarStore, type ChatAvatarRole } from './chatAvatars.js'
+import { applicationMenuTemplate } from './applicationMenu.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -43,7 +44,8 @@ for (const dir of [USER_DATA_DIR, CACHE_DIR]) {
 
 app.setPath('userData', USER_DATA_DIR)
 app.commandLine.appendSwitch('disk-cache-dir', CACHE_DIR)
-Menu.setApplicationMenu(null)
+const menuTemplate = applicationMenuTemplate(process.platform)
+Menu.setApplicationMenu(menuTemplate ? Menu.buildFromTemplate(menuTemplate) : null)
 
 // A packaged build must never trust a process that happens to own the Vite
 // development port. NODE_ENV is not guaranteed to be set by electron-builder,

--- a/electron/tests/applicationMenu.test.mjs
+++ b/electron/tests/applicationMenu.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { applicationMenuTemplate } from '../src/main/applicationMenu.ts'
+
+test('macOS keeps the native edit menu for clipboard shortcuts', () => {
+  assert.deepEqual(applicationMenuTemplate('darwin'), [
+    { role: 'appMenu' },
+    { role: 'editMenu' },
+  ])
+})
+
+test('other desktop platforms keep the application menu hidden', () => {
+  assert.equal(applicationMenuTemplate('win32'), null)
+  assert.equal(applicationMenuTemplate('linux'), null)
+})


### PR DESCRIPTION
## What and why

The Electron main process currently removes the entire application menu on every platform. On macOS, standard text-editing shortcuts such as Command+C, Command+V, Command+X, and Command+A are dispatched through native menu roles, so removing the menu can leave settings fields without working clipboard shortcuts.

This PR keeps only the native app and Edit menus on macOS. Windows and Linux retain the current hidden-menu behavior.

Linked Issue for product-semantic or public-contract changes: none (routine platform fix)

## Change class

- [x] Routine fix, documentation, test, maintenance, or presentation-only UI
- [ ] Product-semantic or public-contract change discussed in the linked Issue
- [ ] Isolated, default-off experiment

Owning layer: Electron application menu initialization

User-visible effect, or `none`: macOS users can use the standard Command-key clipboard and selection shortcuts in editable fields, including provider API-key inputs.

Compatibility or migration impact, or `none`: No migration. Other desktop platforms are unchanged.

## Evidence

Commands and manual journeys run:

- `npm test` — 6 passed
- `npm run build` — passed
- `git diff --check` — passed

- [ ] Relevant Python tests pass
- [x] CPU/model-less baseline remains supported
- [x] Electron `npm run build` passes when Electron code changed
- [ ] Dependency audit passes when dependencies changed
- [ ] Before/after screenshots are attached for visible UI changes
- [ ] Documentation/examples are updated for changed settings or contracts

## Final check

- [x] This PR addresses one coherent problem without unrelated cleanup
- [x] It does not add a speculative API, fallback, or compatibility path
- [x] No secrets, local state, model weights, voice material, or restricted assets are included
- [x] Third-party notices and provenance are preserved
