### PR TITLE
ci: replace flaky npm audit gate with dependency review

### DIFF
--- a/.github/workflows/electron-windows.yml
+++ b/.github/workflows/electron-windows.yml
@@ -34,5 +34,16 @@ jobs:
       - name: Typecheck and build renderer
         run: npm run build
 
-      - name: Audit desktop runtime and build supply chain
-        run: npm audit --audit-level=high
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime, development, unknown
+          license-check: false
+          retry-on-snapshot-warnings: true


### PR DESCRIPTION
`npm audit` currently makes otherwise successful Electron CI jobs fail when npm's Bulk Advisory endpoint times out or returns 5xx, after which npm 10 may fall back to the retiring Quick Audit endpoint. This change keeps the locked install, renderer tests, and production build on Windows, and moves pull-request vulnerability gating to GitHub's dependency review API.

The review blocks high or critical vulnerabilities introduced in runtime, development, or unknown scopes. License checks are disabled here because the previous gate only checked vulnerabilities. Snapshot warnings are retried to tolerate dependency-graph ingestion delays.

Validation:
- parsed the workflow YAML locally;
- checked every configured input against `actions/dependency-review-action@v4`;
- verified this repository's dependency-review API on PR #50;
- confirmed there are currently no open npm Dependabot alerts.

---

当前 `npm audit` 会在 npm Bulk Advisory 接口超时或返回 5xx 时，让安装、测试和构建均已成功的 Electron CI 误报失败；npm 10 还可能回退到即将退役的 Quick Audit 接口。本改动保留 Windows 上的锁定安装、渲染器测试和生产构建，并将 PR 的依赖漏洞门禁迁移到 GitHub dependency review API。

门禁会拦截 PR 新引入的高危或严重漏洞，覆盖运行时、开发及未知依赖范围。这里关闭许可证检查，因为原门禁只检查漏洞；同时对 dependency graph 快照延迟启用重试。

验证：
- 本地解析工作流 YAML；
- 对照 `actions/dependency-review-action@v4` 验证全部输入项；
- 用 PR #50 验证本仓库 dependency-review API 可用；
- 确认当前没有打开的 npm Dependabot 漏洞告警。
