### PR TITLE
fix(chat): compact message bubbles and space messages

### DIFF
--- a/electron/src/renderer/components/ChatBubble.tsx
+++ b/electron/src/renderer/components/ChatBubble.tsx
@@ -9,11 +9,12 @@ interface Props {
   onStreamIdle?: () => void
   userAvatar?: string
   assistantAvatar?: string
+  hasPreviousMessage?: boolean
 }
 
 const DOT_PHASES = ['●', '● ●', '● ● ●', '● ●']
 
-export default function ChatBubble({ role, text, translation = '', streaming, onStreamIdle, userAvatar = '', assistantAvatar = '' }: Props) {
+export default function ChatBubble({ role, text, translation = '', streaming, onStreamIdle, userAvatar = '', assistantAvatar = '', hasPreviousMessage }: Props) {
   const [display, setDisplay] = useState(text)
   const [dotPhase, setDotPhase] = useState(0)
   const [cursorVisible, setCursorVisible] = useState(true)
@@ -60,7 +61,10 @@ export default function ChatBubble({ role, text, translation = '', streaming, on
 
   if (role === 'system') {
     return (
-      <div className="flex justify-center px-[18px] py-[4px]">
+      <div
+        className="flex justify-center px-[18px]"
+        style={{ marginTop: hasPreviousMessage ? 10 : 0 }}
+      >
         <span className="text-[12px] text-[#C42B1C] bg-[#FFF3CD]/60 rounded-lg px-4 py-1.5 max-w-[80%] text-center">
           {text}
         </span>
@@ -73,10 +77,11 @@ export default function ChatBubble({ role, text, translation = '', streaming, on
 
   return (
     <div
-      className="flex items-start gap-[10px] py-[4px]"
+      className="flex items-start gap-[10px]"
       style={{
         flexDirection: isUser ? 'row-reverse' : 'row',
         paddingInline: 'clamp(24px, 2.5vw, 34px)',
+        marginTop: hasPreviousMessage ? 10 : 0,
       }}
     >
       {/* compact desktop avatar */}
@@ -96,8 +101,15 @@ export default function ChatBubble({ role, text, translation = '', streaming, on
           : isUser ? 'U' : 'K'}
       </div>
 
-      {/* bubble — stretch factor 7 */}
-      <div className="flex-[7] min-w-0" style={{ maxWidth: 'calc(100% - 56px)' }}>
+      {/* Keep short messages compact while long messages wrap within the chat lane. */}
+      <div
+        className="min-w-0"
+        style={{
+          flex: '0 1 auto',
+          width: 'fit-content',
+          maxWidth: '70%',
+        }}
+      >
         <div
           className="text-[12px] leading-[150%] whitespace-pre-wrap break-words select-text"
           style={{
@@ -136,8 +148,8 @@ export default function ChatBubble({ role, text, translation = '', streaming, on
         </div>
       </div>
 
-      {/* spacer — stretch factor 3 */}
-      <div className="flex-[3]" />
+      {/* Fill the remaining lane so the bubble stays beside its own avatar. */}
+      <div className="flex-1 min-w-0" />
     </div>
   )
 }

--- a/electron/src/renderer/components/ChatPage.tsx
+++ b/electron/src/renderer/components/ChatPage.tsx
@@ -1365,6 +1365,7 @@ export default function ChatPage({ send, subscribe, connected, renderActive, ren
                   streaming={msg.streaming}
                   userAvatar={chatAvatars.user}
                   assistantAvatar={chatAvatars.assistant}
+                  hasPreviousMessage={i > 0}
                 />
                 {attached.map(activity => (
                   <ChatWorkActivityCard key={activity.runId} activity={activity} />


### PR DESCRIPTION
## What and why

Make chat bubbles fit short content, keep a 70% maximum width for wrapping,
and use a consistent 10px gap between messages.

Linked Issue: none

## Change class

- [x] Routine fix, documentation, test, maintenance, or presentation-only UI

Owning layer: Electron chat message presentation

User-visible effect: Short messages no longer use a fixed-width bubble.

Compatibility or migration impact: none

## Evidence

- `npm test` — passed
- `npm run build` — passed
- `git diff --check` — passed
- Before/after screenshots attached

## Final check

- [x] This PR addresses one coherent problem without unrelated cleanup
- [x] No secrets, local state, model weights, voice material, or restricted assets are included

### Before
<img width="2167" height="1506" alt="download" src="https://github.com/user-attachments/assets/e9455179-fd68-4af3-bf79-ecc07dbdc647" />

### After
<img width="2160" height="1579" alt="无标题" src="https://github.com/user-attachments/assets/9b2563b1-da90-41c9-a275-46f482c5bfbc" />
