### PR TITLE
docs: align English installation guide and refresh star history

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,9 @@ uv run --locked --no-sync python tools\external_assets.py verify C:\path\to\asse
 uv run --locked --no-sync python tools\external_assets.py install C:\path\to\asset-bundle.zip
 uv run --locked --no-sync python tools\external_assets.py status
 ```
-`external_assets.py` 是纯标准库工具，在任一梯级的 `.venv` 下运行均可；本地语音包
-（`asr-qwen3` / `voice-kurisu`）需要 L4 梯级（Windows CUDA）才会被运行时加载。
+`external_assets.py` 是纯标准库工具，在任一梯级的 `.venv` 下运行均可。运行本地语音
+模型还需匹配的模型依赖与硬件，安装资产包本身不会补齐这些依赖。cu124 正式配置和
+ROCm 实验边界见[安装配置](docs/install_profiles.md)。
 
 SpriteForge 角色包最终应落在：
 
@@ -433,7 +434,7 @@ Settings 不会回写 `.env`。普通模型、语音、麦克风、Provider/MCP�
 
 | 范围 | 状态 |
 |---|---|
-| L1/L2（文字 + 远程语音）| Windows 与 macOS 源码部署；macOS 为实测路径，官方 CI/锁文件仍以 Windows 为准 |
+| L1/L2（文字 + 远程语音）| Windows 与 macOS 源码部署；Windows 为参考平台，macOS L1/L2 有独立 CI，桌面与音频体验仍需实机验收 |
 | L3 CPU VAD | 不要求 NVIDIA GPU；使用明确的 CPU 构建配置 |
 | L4 cu124（本地 CUDA 12.4 语音）| Windows + NVIDIA；以当前实际运行环境为参考 |
 | AMD ROCm 7.2.1 | 单 `.venv` 实验锁、sidecar adapter 与失败闭环已提供；受支持 AMD GPU 实机验收待补齐 |
@@ -459,6 +460,7 @@ uv run --locked --no-sync python tools\verify_python_environment.py --profile ci
 uv run --locked --no-sync python -X utf8 tools\run_tests.py
 
 cd electron
+npm ci
 npm run build
 npm audit --audit-level=high
 ```

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,7 +14,7 @@
   <a href="https://www.bilibili.com/video/BV1783G6hEYY/"><img src="https://img.shields.io/badge/demo-Bilibili-2f624a?labelColor=061710&logo=bilibili&logoColor=61eeb6" alt="Bilibili demo"/></a>
   <a href="./assets/architecture-overview-crt.svg"><img src="https://img.shields.io/badge/architecture-current-184b36?labelColor=061710" alt="Current architecture"/></a>
   <img src="https://img.shields.io/badge/version-0.1_%CE%B1-2f624a?labelColor=061710" alt="Amadeus 0.1 alpha"/>
-  <img src="https://img.shields.io/badge/baseline-CUDA%2012.4-c27832?labelColor=061710" alt="CUDA 12.4 local baseline"/>
+  <img src="https://img.shields.io/badge/profiles-core%20%2F%20voice%20%2F%20CPU%20VAD%20%2F%20cu124-2f624a?labelColor=061710" alt="Installation profiles: core, voice, CPU VAD, cu124"/>
   <img src="https://img.shields.io/badge/license-AGPL--3.0-272018?labelColor=061710" alt="License"/>
 </p>
 
@@ -30,6 +30,9 @@
 > Amadeus first-party code is open-source under the
 > [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE).
 > Third-party code and external assets retain their own terms.
+>
+> **Want to run it first?** See [Quick start](#quick-start). For an introduction,
+> start with [What Amadeus is trying to solve](#what-amadeus-is-trying-to-solve).
 
 ## What Amadeus is trying to solve
 
@@ -84,6 +87,28 @@ Host registry; **Main Chat cannot invoke MCP tools directly**. Remote DeepSeek
 is the Main Chat baseline; remote ASR/TTS remain explicit compatibility routes.
 A local voice failure never silently uploads data or creates a second billable request.
 
+## Repository map
+
+```text
+electron/       Electron main, preload, React renderer, and Settings
+server/         authenticated local backend, Host control plane, and AUIP
+core/           Main Chat runtime and session integration
+agent_host/     Provider contracts, adapters, Work identity, and capabilities
+asr/            Conversation / Wake recognition backends
+tts/            synthesis backends, sentence pipeline, playback, and mouth signal
+render/         SpriteForge runtime adapter and PixiJS renderer
+wallpaper/      Electron/Lively hosts and Win32 desktop placement
+vn_player/      experimental VN Player integration
+assets/         Git-owned UI assets and external runtime-asset destinations
+release/        public-source selection, provenance, and deterministic archive policy
+```
+
+`main.py` is not an application entry; it prints a retirement notice. The
+Python entry is `uv run --locked --no-sync python -m server.app --port 17777`,
+and the desktop entry is `run_electron_utf8.bat` on Windows or
+`npm run electron:dev` from `electron/` on macOS. Both discover `.venv`
+automatically; choose an installation profile supported on your platform.
+
 ## Architecture
 
 [![Current Amadeus architecture: Host authority, Work Providers, Provider-scoped MCP/Skills, AUIP AppSessions, voice, and SpriteForge presentation](./assets/architecture-overview-crt.svg)](./assets/architecture-overview-crt.svg)
@@ -125,18 +150,57 @@ The current schema is `amadeus.auip/v0` and is implemented here. See
 public namespace placeholder; this release does not claim a standalone SDK or
 conformance suite.
 
-## Quick start — remote Chat + CUDA 12.4 local voice baseline
+## Quick start
 
-The first release follows the configuration used by the current Amadeus
-runtime: Windows 11, CUDA 12.4, remote DeepSeek Main Chat, local
-Qwen/SenseVoice, and GPT-SoVITS v3. llama.cpp remains an optional local LLM
-profile rather than an installation requirement.
+Dependencies are grouped into four capability tiers. Start with the minimal L1
+installation, then add the tiers you need; Torch enters only at L3/L4. Windows is
+the reference platform, and macOS L1/L2 installation and CI are validated
+separately. Desktop, microphone, and playback behavior still need real-device
+acceptance. L3 offers CPU VAD with **no NVIDIA GPU requirement**. The current L4
+cu124 profile targets Windows + NVIDIA. Windows ROCm 7.2.1 has a mutually exclusive
+`local-rocm` experimental lock and validation tools, but end-to-end acceptance on
+supported AMD hardware remains incomplete. RTX 50-series cu128 remains a community
+configuration record.
+
+All profiles use [uv](https://docs.astral.sh/uv/) and Python 3.12; CI pins uv 0.12.8.
+
+| Tier | Capability | Platform | Installation |
+|---|---|---|---|
+| L1 core | Text Chat, Work, Providers, and character rendering | Windows / macOS | `uv sync --locked` |
+| L2 voice | Remote TTS, playback, lip-sync, microphone, and remote ASR | Windows / macOS | `uv sync --locked --extra voice` |
+| L3 CPU VAD | Real-time interruption while the character is speaking | CPU; no NVIDIA GPU required | `uv sync --locked --extra voice --extra vad --extra torch-cpu` |
+| L4 local-cu124 | Local GPT-SoVITS, Qwen3 ASR, and wake word | Windows + NVIDIA GPU | `uv sync --locked --extra voice --extra vad --extra local-cu124` |
+| Experimental local-rocm | Local GPT-SoVITS / Qwen3 ASR sidecars | Windows + GPU in AMD's official support matrix | `uv sync --locked --extra voice --extra vad --extra local-rocm` |
+
+The four default tiers and the ROCm experiment use **the same `.venv`**. Give the
+complete target configuration each time: `uv sync` is exact and removes packages
+from omitted tiers. `torch-cpu`, `local-cu124`, and `local-rocm` are pairwise
+incompatible. To switch builds, replace the build extra while keeping `voice`
+and `vad`. See [installation profiles and migration](docs/install_profiles.md).
+
+- Main Chat defaults to remote DeepSeek. llama.cpp is an optional local LLM
+  profile under [Compatibility routes](#compatibility-routes), not an installation prerequisite.
+- L2 without VAD uses energy-based endpoint detection. Adding VAD enables
+  Silero endpointing and interruption.
+- On Windows, check each tier with
+  `uv run --locked --no-sync python tools/verify_python_environment.py --profile <cpu|voice|vad-cpu>`
+  (`ci` shares the core import checks). For L4, use `--profile cu124 --require-cuda-device`.
+  For ROCm, use `--profile rocm`, then run the GPU compute probe. Import/build
+  checks do not replace real model and audio-device tests.
+- L1 is sufficient for text-only/headless use. Start the backend with
+  `uv run --locked --no-sync python -m server.app --port 17777`.
+  Set `TTS_BACKEND=disabled` and disable Wake for a strict text-only profile.
 
 ### Reference hardware
 
-- Windows 11
-- CPython **3.12** (`3.12.10` is the current reference)
+**L1/L2 (Windows / macOS)**
+
+- CPython **3.12**, managed by uv; no system Python installation required
 - Node.js **22** (`22.21.1` is the current reference)
+- No GPU required
+
+**Additional requirements for L4 cu124 (Windows local models)**
+
 - CUDA 12.4-compatible NVIDIA GPU, targeting **8 GiB VRAM**
 - **16 GiB system RAM minimum; 32 GiB recommended**
 
@@ -144,18 +208,29 @@ Peak memory depends on local ASR/TTS models and concurrency. The target describe
 the remote-Chat/local-voice profile. An optional local LLM needs additional
 memory according to its model, quantization, context, and GPU offload.
 
-### Install
+### Base environment (L1/L2, Windows / macOS)
 
-Install uv first (`winget install astral-sh.uv`), then:
+Install uv with `winget install astral-sh.uv` on Windows or `brew install uv` on
+macOS. For L2 on macOS, install PortAudio first with `brew install portaudio`;
+PyAudio builds from source there. Then clone and choose a tier with the same
+commands on both platforms:
 
-```powershell
+```bash
 git clone https://github.com/Code-Amadeus/Amadeus.git
 cd Amadeus
 
 uv venv .venv --python 3.12
-uv sync --locked --extra voice --extra vad --extra local-cu124
-uv run --locked --no-sync python tools\verify_python_environment.py --profile cu124 --require-cuda-device
+uv sync --locked                              # L1 core
+uv sync --locked --extra voice                # L2 voice (optional)
+```
 
+Keep the environment named `.venv`. Electron discovers its interpreter
+automatically (`Scripts/python.exe` on Windows, `bin/python3` on macOS), without
+requiring an `AMADEUS_PYTHON` override.
+
+Build the Electron frontend on either platform:
+
+```bash
 cd electron
 npm ci
 npm run build
@@ -163,23 +238,64 @@ cd ..
 ```
 
 `npm ci` uses the project postinstall hook to fetch the pinned Electron runtime.
-The cu124 profile fixes `torch==2.6.0+cu124`, `torchaudio==2.6.0+cu124`, and the
-local-model dependency set; torch/torchaudio are routed to the PyTorch cu124
-index via `[tool.uv.sources]` (Windows + `local-cu124` extra only). All default
-tiers share `.venv`. For CPU VAD, select `--extra voice --extra vad --extra torch-cpu`
-and verify with `--profile vad-cpu`; this does not require a NVIDIA GPU. CPU and
-CUDA build extras are mutually exclusive. `uv sync` is exact: give the complete
-target selection each time, including `--extra dev` when needed.
+Where network access requires it, configure npm/Electron mirrors, such as
+`ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/`.
 
-CI pins uv 0.12.8. Windows is the reference platform; macOS core/voice is being
-qualified separately. An opt-in `local-rocm` selection locks AMD's Windows ROCm
-7.2.1 and Torch 2.9.1 packages into the same project `.venv`; persistent ASR/TTS
-sidecars use that interpreter and remain disabled by default. It is an experimental
-candidate until a supported AMD GPU completes the clean-machine journeys. The
-community-reported RTX 50-series Torch 2.7.0/cu128 combination remains a separate
-configuration record. See [installation profiles and migration](docs/install_profiles.md)
-and the [Windows ROCm sidecar preview](tools/rocm_sidecar/README.md) for commands,
-device gates, evidence limits, and rollback.
+### VAD and local models
+
+Use the same `.venv` as L1/L2 and select the complete capability/build combination.
+
+**L3 CPU VAD — real-time interruption:** Torch enters as a CPU build.
+
+```powershell
+uv sync --locked --extra voice --extra vad --extra torch-cpu
+uv run --locked --no-sync python tools\verify_python_environment.py --profile vad-cpu
+```
+
+**L4 local-cu124 — local voice models:** select the CUDA profile in that same
+environment. On Windows, `[tool.uv.sources]` routes this extra's Torch/Torchaudio
+packages to the PyTorch cu124 index.
+
+```powershell
+uv sync --locked --extra voice --extra vad --extra local-cu124
+uv run --locked --no-sync python tools\verify_python_environment.py --profile cu124 --require-cuda-device
+```
+
+The L4 profile pins `torch==2.6.0+cu124`, `torchaudio==2.6.0+cu124`, and the local
+model dependencies. This is the current qualified local-model profile.
+
+**Experimental local-rocm (Windows):** the same `.venv` can select AMD's official
+ROCm 7.2.1, Torch/Torchaudio 2.9.1, and the local-model dependencies. Persistent
+Qwen ASR and GPT-SoVITS sidecars still use that environment's interpreter by
+default. This option is disabled by default and conflicts with cu124/CPU Torch
+builds. After installation, run the environment check and an actual FP32 GPU
+compute probe before model tests. Do not proceed after a compute failure, even
+if `torch.cuda.is_available()` returns True. Commands, hardware-matrix references,
+and acceptance limits are in the [Windows ROCm sidecar guide](tools/rocm_sidecar/README.md).
+
+The maintainer's Radeon 780M (gfx1103) was detected by ROCm but crashed in an AMD
+HIP DLL on the first FP32 operation. It is absent from AMD's official ROCm 7.2.1
+Windows PyTorch support matrix and is not treated as a usable target.
+
+> **GeForce RTX 50 series (Blackwell, community-validated configuration):**
+> the current `torch==2.6.0+cu124` profile is incompatible with RTX 50-series
+> GPUs and cannot run the local CUDA voice models. Update the NVIDIA driver and
+> use the community-validated PyTorch 2.7.0 CUDA 12.8 combination instead.
+>
+> Run these commands only in a separate experimental project environment, such
+> as `.venv_cu128`; keep the qualified `.venv` and its cu124 lock intact.
+>
+> ```powershell
+> uv venv .venv_cu128 --python 3.12
+> uv pip install --python .venv_cu128 --reinstall `
+>   torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 `
+>   --index-url https://download.pytorch.org/whl/cu128
+> ```
+>
+> This installs only the reported PyTorch combination, not the complete Amadeus
+> environment. It has not passed the project's full clean-install, ASR/TTS/VAD,
+> and Electron regression gates. `uv.lock` and the `--profile cu124` verifier
+> still require `torch==2.6.0+cu124`; this is not a replacement for that baseline.
 
 ### Install external runtime assets
 
@@ -215,25 +331,25 @@ uv run --locked --no-sync python -c "import pyopenjtalk; print(pyopenjtalk.g2p('
 
 ### Configure and launch
 
-```powershell
-Copy-Item .env.example .env
-```
-
-Provide the DeepSeek API key, then review:
+Copy `.env.example` to `.env` (`Copy-Item .env.example .env` on Windows;
+`cp .env.example .env` on macOS), provide the DeepSeek API key, then review Settings:
 
 - **Models:** `deepseek`, the official endpoint, `deepseek-v4-flash`, and an API key;
-- **Voice:** Qwen model directory, GPT-SoVITS **v3** checkpoints, reference audio/text, microphone, AEC, and barge-in;
+- **Voice:** remote TTS/ASR endpoints, such as MiMo; the L4 local stack also needs a Qwen model directory, GPT-SoVITS **v3** checkpoints, reference audio/text, microphone, AEC, and barge-in;
 - **General:** optional character-pack status and presentation settings.
 
-Launch Amadeus directly:
+Launch Amadeus:
 
-```powershell
-.\run_electron_utf8.bat
-```
+- Windows: `run_electron_utf8.bat`, the shared launcher for L1–L4; it discovers `.venv` automatically.
+- macOS: `cd electron && npm run electron:dev`.
 
 Use **Restart backend to apply** after changing startup settings. A
 **Not installed** character pack is healthy and does not disable Chat, Work,
 or headless startup.
+
+The default B2 AppSession action path does not block first-time setup. Chat and
+Settings still start without supported AUIP action-model credentials; application
+actions remain blocked, and Settings displays the missing capability.
 
 ## Compatibility routes
 
@@ -249,22 +365,6 @@ OpenAI-compatible endpoint, and start it when needed:
 
 LM Studio, Ollama, llama-cli, and hybrid profiles remain available, but none is
 an automatic fallback after a DeepSeek failure.
-
-### CPU/model-less
-
-CPU/model-less remains available for CI, headless development, and text
-Chat/Work:
-
-```powershell
-uv venv .venv --python 3.12
-uv sync --locked
-uv run --locked --no-sync python tools\verify_python_environment.py --profile cpu
-.\run_electron_utf8.bat
-```
-
-Set `TTS_BACKEND=disabled` and disable Wake for a strict text-only profile.
-Remote DeepSeek is the first-release Main Chat profile. OpenAI-compatible remote
-ASR/TTS remain explicit compatibility routes.
 
 ### Optional remote model recommendations
 
@@ -296,6 +396,12 @@ uv run --locked --no-sync python tools\external_assets.py verify C:\path\to\asse
 uv run --locked --no-sync python tools\external_assets.py install C:\path\to\asset-bundle.zip
 uv run --locked --no-sync python tools\external_assets.py status
 ```
+
+A bundle can be installed from any tier: `external_assets.py` uses only the
+Python standard library. Running local voice models additionally requires the
+matching model dependencies and hardware; installing a bundle alone does not
+add them. See [installation profiles](docs/install_profiles.md) for the qualified
+cu124 profile and the ROCm experimental boundary.
 
 A SpriteForge character package ultimately lands at:
 
@@ -350,9 +456,12 @@ advanced diagnostics, experimental thresholds, and test-only flags remain in
 
 | Scope | Status |
 |---|---|
-| Windows + remote DeepSeek + CUDA 12.4 local voice | First-release product baseline, following the current working installation |
+| L1/L2 (text + remote voice) | Source deployment on Windows and macOS; Windows is the reference platform, macOS L1/L2 has separate CI, and desktop/audio behavior still needs real-device acceptance |
+| L3 CPU VAD | No NVIDIA GPU required; uses an explicit CPU build selection |
+| L4 cu124 (local CUDA 12.4 voice) | Windows + NVIDIA; follows the qualified local-model configuration |
+| AMD ROCm 7.2.1 | Single-`.venv` experimental lock, sidecar adapters and failure reporting; acceptance on supported AMD hardware remains incomplete |
+| RTX 50-series cu128 | Community configuration record without a formal lock or full regression qualification |
 | 8 GiB VRAM / 16–32 GiB RAM | Target configuration; actual use depends on model selection |
-| CPU/model-less | CI and compatibility path |
 | Remote DeepSeek Main Chat | First-release default profile |
 | Remote ASR / TTS | Explicit compatibility path, never a silent fallback |
 | Electron installer | Not provided yet; launch from source |
@@ -360,14 +469,15 @@ advanced diagnostics, experimental thresholds, and test-only flags remain in
 | SpriteForge character pack | Externally distributed; source starts without it |
 | VTS | Disabled-by-default compatibility route |
 | VN Player | Experimental |
+| Wallpaper mode | Windows hosts only (Lively / Wallpaper Engine); unavailable on other platforms |
 | PyQt / old wallpaper hosts | Retired from public mainline |
 | Claude CLI Provider | Committed future mainline Provider; no live caller yet |
-| Multi-platform support | Future direction, not a current support promise |
 
 ## Development and contribution
 
 ```powershell
-uv sync --locked --extra dev
+uv sync --locked --extra dev      # Core + dev tools; removes unselected voice/model tiers
+# To retain voice/models, append --extra dev to the complete installation command
 uv run --locked --no-sync python tools\verify_python_environment.py --profile ci
 uv run --locked --no-sync python -X utf8 tools\run_tests.py
 
@@ -383,26 +493,6 @@ Providers/MCP/Skills, Projects/Drafts/Artifacts, or AUIP changes should start
 with an Issue. Small fixes, documentation, tests, and presentation-only UI
 changes may open a PR directly. Report security issues privately under
 [SECURITY.md](SECURITY.md).
-
-## Repository map
-
-```text
-electron/       Electron main, preload, React renderer, and Settings
-server/         authenticated local backend, Host control plane, and AUIP
-core/           Main Chat runtime and session integration
-agent_host/     Provider contracts, adapters, Work identity, and capabilities
-asr/            Conversation / Wake recognition backends
-tts/            synthesis backends, sentence pipeline, playback, and mouth signal
-render/         SpriteForge runtime adapter and PixiJS renderer
-wallpaper/      Electron/Lively hosts and Win32 desktop placement
-vn_player/      experimental VN Player integration
-assets/         Git-owned UI assets and external runtime-asset destinations
-release/        public-source selection, provenance, and deterministic archive policy
-```
-
-`main.py` is not an application entry; it prints a retirement notice. The
-Python entry is `uv run --locked --no-sync python -m server.app --port 17777`,
-and the desktop launcher is `run_electron_utf8.bat` (it auto-discovers `.venv`).
 
 ## Public history and license
 

--- a/assets/star-history.svg
+++ b/assets/star-history.svg
@@ -6,8 +6,8 @@
 @media(prefers-color-scheme:dark){.background{fill:#0d1117}.grid{stroke:#30363d}.axis{fill:#8b949e}.heading{fill:#e6edf3}.meta{fill:#8b949e}.line{stroke:#58a6ff}.endpoint{fill:#58a6ff}}
 </style>
 <rect class="background" x="0.5" y="0.5" width="899" height="279" rx="12"/>
-<text class="heading" x="72" y="25">Star growth · 154</text>
-<text class="meta" x="72" y="43">Code-Amadeus/Amadeus · latest star 2026-08-29</text>
+<text class="heading" x="72" y="25">Star growth · 191</text>
+<text class="meta" x="72" y="43">Code-Amadeus/Amadeus · latest star 2026-09-05</text>
 <line class="grid" x1="72" y1="232.0" x2="872" y2="232.0"/>
 <text class="axis" x="60" y="236.0" text-anchor="end">0</text>
 <line class="grid" x1="72" y1="187.5" x2="872" y2="187.5"/>
@@ -19,10 +19,10 @@
 <line class="grid" x1="72" y1="54.0" x2="872" y2="54.0"/>
 <text class="axis" x="60" y="58.0" text-anchor="end">200</text>
 <text class="axis" x="72.0" y="262" text-anchor="start">2026-07-26</text>
-<text class="axis" x="260.2" y="262" text-anchor="middle">2026-08-03</text>
-<text class="axis" x="472.0" y="262" text-anchor="middle">2026-08-12</text>
-<text class="axis" x="683.8" y="262" text-anchor="middle">2026-08-21</text>
-<text class="axis" x="872.0" y="262" text-anchor="end">2026-08-29</text>
-<path class="line" d="M 72.0 232.0 L 72.0 222.2 L 95.5 208.0 L 119.1 203.5 L 142.6 196.4 L 166.1 192.8 L 189.6 188.4 L 213.2 184.8 L 236.7 183.9 L 260.2 180.4 L 283.8 176.8 L 307.3 173.3 L 330.8 170.6 L 354.4 168.8 L 377.9 164.4 L 401.4 161.7 L 424.9 158.1 L 448.5 157.2 L 472.0 152.8 L 495.5 149.2 L 519.1 143.9 L 542.6 141.2 L 566.1 135.0 L 589.6 129.7 L 613.2 127.0 L 636.7 123.4 L 660.2 119.9 L 683.8 117.2 L 707.3 111.8 L 730.8 109.2 L 754.4 107.4 L 777.9 104.7 L 801.4 100.3 L 824.9 98.5 L 848.5 96.7 L 872.0 94.9"/>
-<circle class="endpoint" cx="872.0" cy="94.9" r="4"/>
+<text class="axis" x="267.1" y="262" text-anchor="middle">2026-08-05</text>
+<text class="axis" x="462.2" y="262" text-anchor="middle">2026-08-15</text>
+<text class="axis" x="676.9" y="262" text-anchor="middle">2026-08-26</text>
+<text class="axis" x="872.0" y="262" text-anchor="end">2026-09-05</text>
+<path class="line" d="M 72.0 232.0 L 72.0 222.2 L 91.5 208.0 L 111.0 203.5 L 130.5 196.4 L 150.0 192.8 L 169.6 188.4 L 189.1 184.8 L 208.6 183.9 L 228.1 180.4 L 247.6 176.8 L 267.1 173.3 L 286.6 170.6 L 306.1 168.8 L 325.7 164.4 L 345.2 161.7 L 364.7 158.1 L 384.2 157.2 L 403.7 152.8 L 423.2 149.2 L 442.7 143.9 L 462.2 141.2 L 481.8 135.0 L 501.3 129.7 L 520.8 127.0 L 540.3 123.4 L 559.8 119.9 L 579.3 117.2 L 598.8 111.8 L 618.3 109.2 L 637.9 107.4 L 657.4 104.7 L 676.9 100.3 L 696.4 98.5 L 715.9 96.7 L 735.4 91.4 L 754.9 86.0 L 774.4 79.8 L 794.0 76.2 L 813.5 70.9 L 833.0 65.6 L 852.5 64.7 L 872.0 62.0"/>
+<circle class="endpoint" cx="872.0" cy="62.0" r="4"/>
 </svg>


### PR DESCRIPTION
The English README still presented CUDA local voice as the starting installation path after #46 moved the Chinese guide to capability tiers. This brings the English quick start, hardware requirements, macOS launch commands, profile/rollback guidance, first-run B2 behavior, and release boundaries into alignment. It also corrects two outdated Chinese statements about macOS CI and the distinction between installing assets and installing model dependencies.

The shared Star History SVG is manually regenerated from GitHub's current stargazer timestamps using the existing renderer: **154 → 191 current stars**, latest star date **2026-09-05**. The current chart is referenced by both READMEs.

Validation: checked local Markdown links, code fences and profile commands; parsed the SVG and visually inspected its rendered output; `git diff --check` passed. Documentation and chart changes only.

---

#46 合并后，英文 README 仍把 CUDA 本地语音作为默认安装入口，没有完整同步中文的能力分层。本次补齐英文快速开始、硬件要求、macOS 启动命令、安装配置与回退说明、首次启动的 B2 行为和发布边界；同时修正中文关于 macOS CI 和“安装资产不等于补齐模型依赖”的两处过时表述。

使用现有生成器，根据 GitHub 最新 star 时间戳手动刷新两份 README 共用的 Star History：**154 → 191 星**，最近一颗 star 的日期为 **2026-09-05**。

已检查本地链接、代码围栏、安装配置命令、SVG XML 和实际图表渲染，`git diff --check` 通过。本次仅修改文档与图表。
