### PR TITLE
perf(work): reduce history selection projection overhead

### DIFF
--- a/docs/work_history_projection_performance.md
+++ b/docs/work_history_projection_performance.md
@@ -1,0 +1,42 @@
+# Work history projection performance
+
+Selecting a historical WorkItem validates the current revision, changes only the
+view selection, and publishes a fresh Work/Canvas projection. It must not change
+workspace routing or authorize execution.
+
+The projection path now avoids three sources of repeated filesystem work:
+
+- A valid selection no longer prepares an extra snapshot used only by the
+  missing-revision error response.
+- Workspace-root matching checks resolved containment first. Git identity is used
+  only for linked worktrees outside the configured roots. An empty registry denies
+  without spawning Git; unrelated repositories remain denied.
+- A synchronous batch of WorkReadModel rows reads shared workspace existence,
+  scratch membership and Draft retention once per path. This reuse ends with the
+  call. Subsequent projections recheck filesystem changes. Attempt, permission,
+  completion and liveness facts remain per-item reads.
+
+No default host, mouse-through policy or visual behavior changes. No persistent
+trust cache or model/provider-specific path is introduced.
+
+## Validation
+
+Focused tests cover trusted containment, linked worktrees, untrusted roots,
+missing/stale revision rejection, read-only projection, equivalence with single-row
+projection, and directory disappearance/reappearance between calls.
+
+Windows measurements used the real handler with a temporary SQLite ledger, one
+registered Project and an existing scratch root, two warmups and 12 samples
+(8 for separate directories):
+
+| Generated history | Before median | After median |
+| --- | ---: | ---: |
+| 24 tasks, shared directory | 577 ms | 23 ms |
+| 200 tasks, shared directory | 2073 ms | 62 ms |
+| 24 tasks, separate directories | 661 ms | 158 ms |
+
+These are handler-only measurements, not input-to-screen latency guarantees.
+The fixtures have no attempts or permissions and do not represent every user
+history. A local Lively integration with a temporary real ledger and generated
+reports also completed selection-to-DOM checks. Physical mouse delivery and
+switching the default Canvas host require separate qualification.

--- a/server/handlers/work_ledger_handler.py
+++ b/server/handlers/work_ledger_handler.py
@@ -386,8 +386,8 @@ class WorkLedgerHandler(RequestHandler):
                 **result,
             }
         if action == "select":
-            current = self.coordinator.snapshot(surface=DEFAULT_WORK_SURFACE)
             if not revision:
+                current = self.coordinator.snapshot(surface=DEFAULT_WORK_SURFACE)
                 return {
                     "ok": False,
                     "error": "missing_revision",

--- a/server/work_ledger_coordinator.py
+++ b/server/work_ledger_coordinator.py
@@ -5428,7 +5428,7 @@ class WorkLedgerCoordinator:
         target_surface = str(surface or self.default_surface)
         current_session_id = str(self._current_session_id() or "").strip()
         records = self.store.list_work_items(limit=limit)
-        items = [self._project_item(item) for item in records]
+        items = self.read_model.project_items(records)
         focus = self.store.get_focus(target_surface)
         if (
             target_surface != WORKSPACE_ROUTING_SURFACE

--- a/server/work_read_model.py
+++ b/server/work_read_model.py
@@ -67,10 +67,9 @@ class WorkReadModel:
         project = self.store.get_project(str(project_id or "").strip())
         if project is None:
             return None
-        projected = [
-            self.project_item(item)
-            for item in self.store.list_work_items(project_id=project.project_id, limit=200)
-        ]
+        projected = self.project_items(
+            self.store.list_work_items(project_id=project.project_id, limit=200)
+        )
         current = [
             item for item in projected if item.get("state") not in {"accepted", "archived"}
         ]
@@ -226,6 +225,34 @@ class WorkReadModel:
         return str(min(candidates, key=rank).get("id") or "")
 
     def project_item(self, item: WorkItemRecord) -> dict[str, Any]:
+        return self._project_item(item, self._workspace_facts(item))
+
+    def project_items(self, items: list[WorkItemRecord]) -> list[dict[str, Any]]:
+        # A synchronous projection reads shared workspace facts once. Nothing
+        # survives this call: later projections recheck deletion, moves and Draft
+        # retention. Per-attempt permissions and completion remain per-item reads.
+        workspaces: dict[str, tuple[bool, bool, bool]] = {}
+        projected: list[dict[str, Any]] = []
+        for item in items:
+            key = item.workspace_path if item.workspace_mode != "none" else ""
+            if key not in workspaces:
+                workspaces[key] = self._workspace_facts(item)
+            projected.append(self._project_item(item, workspaces[key]))
+        return projected
+
+    def _workspace_facts(self, item: WorkItemRecord) -> tuple[bool, bool, bool]:
+        if item.workspace_mode == "none":
+            return False, False, False
+        return (
+            Path(item.workspace_path).is_dir(),
+            is_scratch_path(item.workspace_path),
+            bool(self._is_unkept_draft(item.workspace_path)),
+        )
+
+    def _project_item(
+        self, item: WorkItemRecord, workspace_facts: tuple[bool, bool, bool]
+    ) -> dict[str, Any]:
+        workspace_exists, is_scratch, unkept_draft = workspace_facts
         operations = self.store.list_operations(item.work_item_id)
         attempts = self.store.list_attempts(item.work_item_id)
         latest_attempt = attempts[-1] if attempts else None
@@ -288,7 +315,6 @@ class WorkReadModel:
         )
         recoverable_export = recoverable_exports[-1] if recoverable_exports else None
         has_workspace = item.workspace_mode != "none"
-        workspace_exists = bool(has_workspace and Path(item.workspace_path).is_dir())
         if execution == "orphaned" or (has_workspace and not workspace_exists):
             attention = "error"
         elif pending_permissions:
@@ -400,8 +426,6 @@ class WorkReadModel:
             Path(item.workspace_path).name or item.workspace_mode if has_workspace else ""
         )
         metadata = dict(item.metadata or {})
-        is_scratch = bool(has_workspace and is_scratch_path(item.workspace_path))
-        unkept_draft = bool(has_workspace and self._is_unkept_draft(item.workspace_path))
         project = self.store.get_project(item.project_id)
         project_name = (
             "" if unkept_draft or not has_workspace else str(project.name if project else "")

--- a/server/workspace_trust.py
+++ b/server/workspace_trust.py
@@ -40,7 +40,7 @@ def cwd_matches_workspace_roots(
         target = Path(cwd).resolve()
     except (OSError, RuntimeError, ValueError):
         return False
-    target_repository = _git_repository_identity(target)
+    resolved_roots: list[Path] = []
     for item in roots:
         try:
             root = Path(item).resolve()
@@ -48,10 +48,18 @@ def cwd_matches_workspace_roots(
             continue
         if _same_or_child(target, root):
             return True
+        resolved_roots.append(root)
+    # Containment is already sufficient authority. Git identity is needed only
+    # for a linked worktree outside every configured root, never an empty list.
+    if not resolved_roots:
+        return False
+    target_repository = _git_repository_identity(target)
+    if target_repository is None:
+        return False
+    for root in resolved_roots:
         root_repository = _git_repository_identity(root)
         if (
-            target_repository is not None
-            and root_repository is not None
+            root_repository is not None
             and _same_path(
                 target_repository["common_dir"],
                 root_repository["common_dir"],

--- a/tests/test_project_registry.py
+++ b/tests/test_project_registry.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -16,6 +17,19 @@ from server.project_registry import (
 )
 from server.scratch_workspace import ensure_scratch_root
 from server.work_ledger_coordinator import WorkLedgerCoordinator
+from server.workspace_trust import cwd_matches_workspace_roots
+
+
+def test_containment_and_empty_registry_do_not_require_git(tmp_path: Path) -> None:
+    trusted = tmp_path / "trusted"
+    child = trusted / "child"
+    unrelated = tmp_path / "unrelated"
+    child.mkdir(parents=True)
+    unrelated.mkdir()
+    with patch("server.workspace_trust._git_repository_identity", side_effect=AssertionError("Git is unnecessary")):
+        assert cwd_matches_workspace_roots(str(child), []) is False
+        assert cwd_matches_workspace_roots(str(trusted), [str(trusted)]) is True
+        assert cwd_matches_workspace_roots(str(child), [str(unrelated), str(trusted)]) is True
 
 
 def _git(cwd: Path, *args: str) -> None:

--- a/tests/test_work_ledger_handler.py
+++ b/tests/test_work_ledger_handler.py
@@ -134,6 +134,13 @@ def test_canvas_route_binds_selection_focus_and_execution_to_canonical_task() ->
                 def current_revision() -> str:
                     return str(coordinator.snapshot()["revision"])
 
+                before_missing = coordinator.snapshot()
+                missing_select_revision = await handler.route_action(
+                    {"action": "select", "workItemId": item_b}
+                )
+                assert missing_select_revision["error"] == "missing_revision"
+                assert missing_select_revision["work"]["selectedWorkItemId"] == before_missing["selectedWorkItemId"]
+
                 selected = await handler.route_action(
                     {
                         "action": "select",

--- a/tests/test_work_read_model.py
+++ b/tests/test_work_read_model.py
@@ -118,6 +118,27 @@ def test_latest_attempt_never_inherits_an_older_completion() -> None:
             assert row["completionRationale"] == ""
 
 
+def test_batch_projection_matches_single_items_and_rechecks_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    with WorkLedgerStore(tmp_path / "ledger.sqlite3", clock=lambda: 10.0) as store:
+        project = store.create_or_get_project(workspace)
+        items = [store.create_work_item(project.project_id, title=f"Task {i}") for i in range(2)]
+        items.append(store.create_work_item(project.project_id, title="No workspace", workspace_mode="none"))
+        model = _model(store)
+        before = [_durable_facts(store, item.work_item_id) for item in items]
+        assert model.project_items(items) == [model.project_item(item) for item in items]
+        assert [_durable_facts(store, item.work_item_id) for item in items] == before
+
+        workspace.rmdir()
+        missing = model.project_items(items)
+        assert all(row["workspaceExists"] is False for row in missing)
+        assert [row["attention"] for row in missing] == ["error", "error", "none"]
+        workspace.mkdir()
+        restored = model.project_items(items)
+        assert [row["workspaceExists"] for row in restored] == [True, True, False]
+
+
 def test_projection_exposes_existing_attempt_session_identity() -> None:
     with tempfile.TemporaryDirectory(prefix="work_read_session_") as temp:
         root = Path(temp)


### PR DESCRIPTION
## What and why

Selecting a historical WorkItem repeatedly rebuilt the same projection and repeated filesystem/Git checks before the Canvas could display the selected report. This reduces that work while retaining fresh revision validation, workspace routing, permission, completion and recovery boundaries.

- Avoid the extra snapshot used only by the missing-revision error response on valid selections.
- Resolve trusted-root containment before consulting Git for linked worktrees; an empty registry still denies.
- Share workspace existence and Draft classification only within one synchronous batch projection. Every subsequent projection rechecks them, and per-item attempt/permission/completion facts remain independent.

Linked Issue: none; this preserves existing product semantics and public contracts.

## Change class

- [x] Routine fix, documentation, test, maintenance, or presentation-only UI
- [ ] Product-semantic or public-contract change discussed in the linked Issue
- [ ] Isolated, default-off experiment

Owning layer: Host Work read model, history selection handler and workspace-root matching.

User-visible effect: Faster historical-task selection. No default Canvas host or mouse-through changes.

Compatibility or migration impact: none.

## Evidence

- 43 focused tests passed for Project Registry, WorkLedgerHandler, WorkReadModel, scratch destinations and workspace-less Providers. The same focused tests also passed against the internal mainline integration.
- Ruff and git diff --check passed.
- Temporary-ledger Windows handler measurements: 24 tasks sharing a directory, median 577 ms to 23 ms; 200 sharing a directory, 2073 ms to 62 ms; 24 separate directories, 661 ms to 158 ms. These exclude physical input, network and drawing; fixture details and limitations are in docs/work_history_projection_performance.md.
- A local Lively integration with the real temporary ledger and generated historical reports completed script-click-to-content checks. This does not qualify physical hit testing or a switch to inline Canvas.
- No Electron code, dependencies, user data, model assets or experimental web servers are included.

- [x] Relevant Python tests pass
- [x] CPU/model-less baseline remains supported
- [x] Documentation/examples are updated

## Final check

- [x] One coherent performance problem without unrelated cleanup
- [x] No persistent trust cache, speculative fallback or provider-specific path
- [x] No secrets, local state, model weights, voice material or restricted assets
- [x] Third-party notices and provenance preserved
