### PR TITLE
ci: add Linux core qualification

### DIFF
--- a/.github/workflows/python-linux.yml
+++ b/.github/workflows/python-linux.yml
@@ -1,0 +1,72 @@
+name: Python Linux
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  core-tier:
+    # Phase 1 Linux regression baseline: L1 core + dev tooling, platform-safe
+    # contract tests, and Electron build. Full Linux support is a separate effort.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      AMADEUS_E2E_NO_TTS: "1"
+      TTS_DEVICE: "cpu"
+      WORK_WORKTREE_ISOLATION: "0"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12.10"
+
+      - name: Install pinned uv
+        run: python -m pip install uv==0.12.8
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22.21.1"
+          cache: npm
+          cache-dependency-path: electron/package-lock.json
+
+      - name: Install locked environment (L1 + dev tooling)
+        run: uv sync --locked --extra dev
+
+      - name: Verify environment (ci profile)
+        run: uv run --locked --no-sync python tools/verify_python_environment.py --profile ci
+
+      - name: Assert L1 stays model-less
+        run: >-
+          uv run --locked --no-sync python -c
+          "import importlib.util as u;
+          assert all(u.find_spec(n) is None
+          for n in ('torch', 'torchaudio', 'pyaudio', 'silero_vad', 'onnxruntime'))"
+
+      - name: Check source and architecture views
+        shell: bash
+        run: |
+          uv run --locked --no-sync python -m ruff check .
+          uv run --locked --no-sync python tools/architecture/generate_views.py --check
+
+      - name: Run platform-safe contract suites
+        shell: bash
+        # Same whitelist as macOS: contract tests without platform-specific
+        # runtime execution or browser/Electron spawning.
+        run: >-
+          uv run --locked --no-sync python -m pytest -q
+          tests/test_profile_contract.py
+          tests/test_python_environment_verifier.py
+          tests/test_cu124_dependency_audit_tool.py
+          tests/test_core_install_tiers.py
+          tests/test_asset_paths.py
+          tests/test_system_settings.py
+          tests/test_voice_backend_registry.py
+
+      - name: Build Electron renderer (Linux)
+        working-directory: electron
+        run: |
+          npm ci
+          npm run build


### PR DESCRIPTION
## 概述

Related to #64

为 Linux 增加第一阶段 Core CI qualification。

目前经过 Arch Linux + Wayland 实机验证，Amadeus 的 L1 Core / Backend、Electron build 和 Electron desktop 已经可以正常运行。

这个 PR 不引入新的 Linux runtime implementation，而是为当前已经能够工作的跨平台路径建立一个最小的 Linux regression baseline，避免后续修改在没有发现的情况下破坏 Linux 基础兼容性。

## 改动内容

新增：

```text
.github/workflows/python-linux.yml
```

使用 GitHub-hosted：

```text
ubuntu-24.04
```

环境版本与项目现有 CI 保持一致：

- Python 3.12.10
- uv 0.12.8
- Node.js 22.21.1

当前 workflow 验证：

- `uv sync --locked --extra dev`
- `ci` environment verifier
- L1 model-less dependency contract
- Ruff
- architecture view check
- 与现有 macOS CI 对齐的 platform-safe contract test subset
- Electron `npm ci`
- Electron `npm run build`

## Scope

这个 PR 有意保持较小范围。

当前不包含：

- Voice / AEC
- CPU VAD
- CUDA / `local-cu124`
- Electron GUI runtime
- Wayland session
- Wallpaper integration

其中 Voice / AEC 和 Linux NVIDIA dependency profile 会作为后续独立问题处理。

本 PR 也不会修改当前 Windows / macOS runtime 行为或现有平台支持范围。

## 验证

提交前已在 Arch Linux 实机环境完成对应检查：

- environment verifier (`--profile ci`)：通过
- L1 model-less dependency assertion：通过
- Ruff：通过
- architecture view check：通过
- platform-safe tests：通过（65 passed, 1 skipped）
- Electron `npm ci`：通过
- Electron `npm run build`：通过

GitHub-hosted Ubuntu qualification 将由本 PR 的 `pull_request` workflow 进行验证。

## 目的

这一步主要是把：

> Linux Core / Electron build 当前可以工作

进一步固化为：

> Linux Core / Electron build 有持续 CI regression protection

后续再基于 tracking Issue 中的计划逐步补充其他 Linux qualification。