### PR TITLE
docs: add experimental Linux setup to Chinese and English READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ L4 的当前 cu124 配置面向 Windows + NVIDIA。Windows ROCm 7.2.1 已有互�
 cu128 仍是社区配置记录。
 统一使用 [uv](https://docs.astral.sh/uv/) 与 Python 3.12，CI 固定 uv 0.12.8。
 
+Linux 用户请从下方的 [Linux（实验性）](#linux实验性) 章节开始。
+
 | 梯级 | 能力 | 平台 | 安装方式 |
 |---|---|---|---|
 | L1 core | 文字聊天、工作、Provider、角色渲染 | Windows / macOS | `uv sync --locked` |
@@ -220,6 +222,61 @@ cd ..
 
 `npm ci` 会通过项目 postinstall 安装锁定的 Electron 运行时。国内网络可为
 npm/Electron 配置镜像（如 `ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/`）。
+
+### Linux（实验性）
+
+**Linux 目前属于实验性源码运行路径，尚未纳入完整支持的平台范围。**
+[第一阶段 Linux CI（#63）](https://github.com/Code-Amadeus/Amadeus/pull/63) 已通过
+Ubuntu 24.04 上的 L1 + dev 锁定安装、环境导入与无模型依赖检查、基础契约测试、
+Ruff、架构视图检查及 Electron 构建。CI 不覆盖 Electron GUI、音频设备、
+VAD、本地模型推理、Wayland 会话或壁纸集成。
+
+社区已报告 Arch Linux / Wayland 下的桌面与角色渲染等实机结果；这些结果不代表
+所有发行版或桌面环境均已验证。环境记录、已知问题和后续进展见
+[Linux 跟踪 issue #64](https://github.com/Code-Amadeus/Amadeus/issues/64)。
+
+先安装 Git、[uv](https://docs.astral.sh/uv/)（CI 使用 `0.12.8`）和 Node.js 22
+（CI 使用 `22.21.1`），从无需 GPU 或语音包的 L1 开始：
+
+```bash
+git clone https://github.com/Code-Amadeus/Amadeus.git
+cd Amadeus
+uv venv .venv --python 3.12.10
+uv sync --locked
+cp .env.example .env
+```
+
+编辑 `.env`，填写 `DEEPSEEK_API_KEY`，设置 `TTS_BACKEND=disabled`，并保持
+`WAKE_ENABLED=false`，先验证文字路径。然后在项目根目录检查环境：
+
+```bash
+uv run --locked --no-sync python tools/verify_python_environment.py --profile cpu
+```
+
+在 Linux 图形桌面会话中构建并启动 Electron；启动器会自动发现
+`.venv/bin/python3` 并启动后端：
+
+```bash
+cd electron
+npm ci
+npm run build
+npm run electron:dev
+```
+
+如只需 headless 后端，可改为在项目根目录运行：
+
+```bash
+uv run --locked --no-sync python -m server.app --port 17777
+```
+
+升级到语音或本地模型前，请留意以下实验边界：
+
+- **Voice / AEC**：社区报告 `aec-audio-processing==1.0.1` 在 Arch 的较新工具链上
+  编译失败，会阻塞 `--extra voice` 安装；尚不能将该问题推广到所有 Linux 发行版。
+- **VAD / NVIDIA**：已有社区实机推理报告，但未纳入 Linux CI；当前 CPU/cu124
+  PyTorch 索引选择仅对 Windows 生效，Linux 的可复现构建配置仍待完善。
+- **桌面 / 壁纸**：GUI 与 Wayland compositor 集成仍需分别验收；GNOME 的社区结果
+  不代表 niri、KDE 或其他桌面也可用。
 
 ### VAD 与本地模型
 
@@ -445,6 +502,7 @@ Settings 不会回写 `.env`。普通模型、语音、麦克风、Provider/MCP�
 | 范围 | 状态 |
 |---|---|
 | L1/L2（文字 + 远程语音）| Windows 与 macOS 源码部署；Windows 为参考平台，macOS L1/L2 有独立 CI，桌面与音频体验仍需实机验收 |
+| Linux（实验性）| Ubuntu 24.04 的 L1 基础检查与 Electron 构建有 CI；GUI、语音、GPU 与壁纸尚未完成正式验收，见 [Linux 章节](#linux实验性) |
 | L3 CPU VAD | 不要求 NVIDIA GPU；使用明确的 CPU 构建配置 |
 | L4 cu124（本地 CUDA 12.4 语音）| Windows + NVIDIA；以当前实际运行环境为参考 |
 | AMD ROCm 7.2.1 | 单 `.venv` 实验锁、sidecar adapter 与失败闭环已提供；受支持 AMD GPU 实机验收待补齐 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -165,6 +165,8 @@ configuration record.
 
 All profiles use [uv](https://docs.astral.sh/uv/) and Python 3.12; CI pins uv 0.12.8.
 
+Linux users should start with [Linux (experimental)](#linux-experimental) below.
+
 | Tier | Capability | Platform | Installation |
 |---|---|---|---|
 | L1 core | Text Chat, Work, Providers, and character rendering | Windows / macOS | `uv sync --locked` |
@@ -241,6 +243,67 @@ cd ..
 `npm ci` uses the project postinstall hook to fetch the pinned Electron runtime.
 Where network access requires it, configure npm/Electron mirrors, such as
 `ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/`.
+
+### Linux (experimental)
+
+**Linux is currently an experimental source deployment path, with full platform
+support still pending.** [Phase 1 Linux CI (#63)](https://github.com/Code-Amadeus/Amadeus/pull/63)
+has passed locked L1 + dev installation, environment imports and model-less
+dependency checks, basic contract tests, Ruff, architecture-view checks, and the
+Electron build on Ubuntu 24.04. CI does not cover the Electron GUI, audio devices,
+VAD, local model inference, Wayland sessions, or wallpaper integration.
+
+The community has reported desktop and character-rendering results on Arch Linux /
+Wayland. These reports do not establish compatibility across all distributions or
+desktop environments. See [Linux tracking issue #64](https://github.com/Code-Amadeus/Amadeus/issues/64)
+for environment records, known issues, and follow-up work.
+
+Install Git, [uv](https://docs.astral.sh/uv/) (`0.12.8` in CI), and Node.js 22
+(`22.21.1` in CI), then start with L1, which needs no GPU or voice packages:
+
+```bash
+git clone https://github.com/Code-Amadeus/Amadeus.git
+cd Amadeus
+uv venv .venv --python 3.12.10
+uv sync --locked
+cp .env.example .env
+```
+
+Edit `.env`, provide `DEEPSEEK_API_KEY`, set `TTS_BACKEND=disabled`, and keep
+`WAKE_ENABLED=false` to try the text-only path first. Verify the environment from
+the project root:
+
+```bash
+uv run --locked --no-sync python tools/verify_python_environment.py --profile cpu
+```
+
+Build and launch Electron from a Linux graphical desktop session. The launcher
+automatically discovers `.venv/bin/python3` and starts the backend:
+
+```bash
+cd electron
+npm ci
+npm run build
+npm run electron:dev
+```
+
+For a headless backend instead, run this from the project root:
+
+```bash
+uv run --locked --no-sync python -m server.app --port 17777
+```
+
+Before adding voice or local models, consider these experimental boundaries:
+
+- **Voice / AEC:** the community reports that `aec-audio-processing==1.0.1` fails
+  to compile with a newer Arch toolchain, blocking `--extra voice` installation.
+  This has not been established as a problem on all Linux distributions.
+- **VAD / NVIDIA:** community inference results exist, but Linux CI does not cover
+  them. The current CPU/cu124 PyTorch index selection only applies on Windows;
+  reproducible Linux build profiles still need work.
+- **Desktop / wallpaper:** GUI and Wayland compositor integration need separate
+  acceptance. Community GNOME results do not establish support for niri, KDE, or
+  other desktops.
 
 ### VAD and local models
 
@@ -473,6 +536,7 @@ advanced diagnostics, experimental thresholds, and test-only flags remain in
 | Scope | Status |
 |---|---|
 | L1/L2 (text + remote voice) | Source deployment on Windows and macOS; Windows is the reference platform, macOS L1/L2 has separate CI, and desktop/audio behavior still needs real-device acceptance |
+| Linux (experimental) | Ubuntu 24.04 CI covers basic L1 checks and the Electron build; GUI, voice, GPU, and wallpaper acceptance remains incomplete. See [Linux setup](#linux-experimental) |
 | L3 CPU VAD | No NVIDIA GPU required; uses an explicit CPU build selection |
 | L4 cu124 (local CUDA 12.4 voice) | Windows + NVIDIA; follows the qualified local-model configuration |
 | AMD ROCm 7.2.1 | Single-`.venv` experimental lock, sidecar adapters and failure reporting; acceptance on supported AMD hardware remains incomplete |


### PR DESCRIPTION
## What and why

Following #63, the Chinese and English READMEs lack a Linux entry point. Add matching experimental Linux sections with L1 installation, text-only configuration, environment verification, and Electron/headless launch commands. Distinguish Ubuntu CI coverage from community device reports and document the remaining AEC, PyTorch profile, and desktop/wallpaper limitations.

Related to #64; this documents the existing experiment without expanding the supported platform baseline.

## Change class

- [x] Routine fix, documentation, test, maintenance, or presentation-only UI
- [ ] Product-semantic or public-contract change discussed in the linked Issue
- [ ] Isolated, default-off experiment

Owning layer: Chinese and English README setup and release-boundary documentation.

User-visible effect: Linux readers can find an explicitly experimental L1 setup path and its validation limits.

Compatibility or migration impact: none.

## Evidence

- `git diff --check` passed before commit.
- Reviewed both language versions for equivalent commands and scope.
- Checked commands and settings against `.github/workflows/python-linux.yml`, `electron/package.json`, the Electron Python discovery code, `.env.example`, and `pyproject.toml`.
- Documentation only; no new Linux GUI or hardware tests were run. Existing Ubuntu CI evidence is linked through #63.

- [x] Documentation/examples are updated for changed settings or contracts

## Final check

- [x] This PR addresses one coherent problem without unrelated cleanup
- [x] It does not add a speculative API, fallback, or compatibility path
- [x] No secrets, local state, model weights, voice material, or restricted assets are included
- [x] Third-party notices and provenance are preserved
